### PR TITLE
Implement multi-endpoint support for Jarvis SDK

### DIFF
--- a/example_app.py
+++ b/example_app.py
@@ -1,21 +1,53 @@
-"""Example endpoint for testing startup time."""
+"""Example multi-endpoint Calculator app demonstrating Jarvis SDK usage."""
 
 import jarvis
 from pydantic import BaseModel
 
 
-class Input(BaseModel):
-    name: str
+class AddInput(BaseModel):
+    """Input model for the add endpoint."""
+    a: float
+    b: float
 
 
-class Output(BaseModel):
-    message: str
+class AddOutput(BaseModel):
+    """Output model for the add endpoint."""
+    result: float
 
 
-@jarvis.endpoint()
-class Greeter:
+class SubtractInput(BaseModel):
+    """Input model for the subtract endpoint."""
+    a: float
+    b: float
+
+
+class SubtractOutput(BaseModel):
+    """Output model for the subtract endpoint."""
+    result: float
+
+
+@jarvis.app()
+class Calculator:
+    """A simple calculator with add and subtract operations.
+
+    This demonstrates:
+    - Multiple endpoints in a single app class
+    - Shared state via setup() method
+    - Pydantic models for input/output validation
+    """
+
     def setup(self):
-        self.prefix = "Hello"
+        """Initialize shared state. Called once on app startup."""
+        self.operation_count = 0
 
-    def run(self, input: Input) -> Output:
-        return Output(message=f"{self.prefix}, {input.name}!")
+    @jarvis.endpoint()
+    def add(self, input: AddInput) -> AddOutput:
+        """Add two numbers together."""
+        self.operation_count += 1
+        return AddOutput(result=input.a + input.b)
+
+    @jarvis.endpoint()
+    def subtract(self, input: SubtractInput) -> SubtractOutput:
+        """Subtract b from a."""
+        self.operation_count += 1
+        return SubtractOutput(result=input.a - input.b)

--- a/jarvis/__init__.py
+++ b/jarvis/__init__.py
@@ -1,6 +1,6 @@
 """Jarvis SDK - A simple framework for creating ML endpoints."""
 
-from jarvis.decorator import endpoint
+from jarvis.decorator import app, endpoint
 
 __version__ = "0.1.0"
-__all__ = ["endpoint"]
+__all__ = ["app", "endpoint"]

--- a/jarvis/cli_test.py
+++ b/jarvis/cli_test.py
@@ -11,6 +11,8 @@ runner = CliRunner()
 
 
 class TestDevCommand:
+    """Tests for the dev command."""
+
     def test_help_shows_dev_command(self):
         result = runner.invoke(app, ["--help"])
         assert result.exit_code == 0
@@ -44,7 +46,8 @@ class TestDevCommand:
         finally:
             Path(temp_path).unlink()
 
-    def test_dev_no_endpoint_found(self):
+    def test_dev_no_app_found(self):
+        """Test error message when no @jarvis.app() decorated class is found."""
         with tempfile.NamedTemporaryFile(suffix=".py", delete=False) as f:
             f.write(b"# empty python file\nx = 1\n")
             temp_path = f.name
@@ -52,7 +55,29 @@ class TestDevCommand:
         try:
             result = runner.invoke(app, ["dev", temp_path])
             assert result.exit_code == 1
-            assert "No endpoints found" in result.output
+            assert "No apps found" in result.output
+            assert "@jarvis.app()" in result.output
+        finally:
+            Path(temp_path).unlink()
+
+    def test_dev_app_with_no_endpoints(self):
+        """Test error message when app has no @jarvis.endpoint() methods."""
+        with tempfile.NamedTemporaryFile(suffix=".py", delete=False) as f:
+            code = b"""
+import jarvis
+
+@jarvis.app()
+class EmptyApp:
+    pass
+"""
+            f.write(code)
+            temp_path = f.name
+
+        try:
+            result = runner.invoke(app, ["dev", temp_path])
+            assert result.exit_code == 1
+            assert "no endpoints" in result.output.lower()
+            assert "@jarvis.endpoint()" in result.output
         finally:
             Path(temp_path).unlink()
 
@@ -63,3 +88,58 @@ class TestDevCommand:
     def test_dev_port_option_short_flag(self):
         result = runner.invoke(app, ["dev", "--help"])
         assert "-p" in result.output
+
+
+class TestDevCommandValidation:
+    """Tests for dev command validation of apps."""
+
+    def test_valid_app_imports_correctly(self):
+        """Test that a valid multi-endpoint app can be imported and validated."""
+        # This test verifies the import and validation logic works
+        # without actually starting the server
+        import importlib.util
+        import sys
+
+        from jarvis.decorator import clear_registry, get_endpoint_methods, get_registered_apps
+
+        with tempfile.NamedTemporaryFile(suffix=".py", delete=False) as f:
+            code = b"""
+import jarvis
+from pydantic import BaseModel
+
+class Input(BaseModel):
+    value: int
+
+class Output(BaseModel):
+    result: int
+
+@jarvis.app()
+class Calculator:
+    @jarvis.endpoint()
+    def add(self, input: Input) -> Output:
+        return Output(result=input.value + 1)
+
+    @jarvis.endpoint()
+    def subtract(self, input: Input) -> Output:
+        return Output(result=input.value - 1)
+"""
+            f.write(code)
+            temp_path = f.name
+
+        try:
+            clear_registry()
+            spec = importlib.util.spec_from_file_location("test_module", temp_path)
+            module = importlib.util.module_from_spec(spec)
+            sys.modules["test_module"] = module
+            spec.loader.exec_module(module)
+
+            apps = get_registered_apps()
+            assert len(apps) == 1
+            assert apps[0]._jarvis_app_name == "Calculator"
+
+            methods = get_endpoint_methods(apps[0])
+            assert len(methods) == 2
+        finally:
+            Path(temp_path).unlink()
+            if "test_module" in sys.modules:
+                del sys.modules["test_module"]

--- a/jarvis/decorator.py
+++ b/jarvis/decorator.py
@@ -1,33 +1,80 @@
-"""Decorator for defining Jarvis endpoints."""
+"""Decorators for defining Jarvis apps and endpoints."""
 
-from typing import Type
+import functools
+from typing import Callable, Optional, Type
 
-# Registry to track all decorated endpoint classes
-_endpoint_registry: list[Type] = []
+# Registry to track all decorated app classes
+_app_registry: list[Type] = []
 
 
-def endpoint():
-    """Decorator to mark a class as a Jarvis endpoint.
+def app(name: Optional[str] = None):
+    """Decorator to mark a class as a Jarvis app.
 
-    The endpoint name is automatically derived from the class name.
+    The app can contain multiple endpoint methods decorated with @endpoint().
+
+    Args:
+        name: Optional custom name for the app. Defaults to the class name.
 
     Returns:
-        A decorator function that registers the class as an endpoint.
+        A decorator function that registers the class as an app.
     """
 
     def decorator(cls: Type) -> Type:
-        cls._jarvis_endpoint_name = cls.__name__
-        _endpoint_registry.append(cls)
+        cls._jarvis_app = True
+        cls._jarvis_app_name = name if name else cls.__name__
+        _app_registry.append(cls)
         return cls
 
     return decorator
 
 
-def get_registered_endpoints() -> list[Type]:
-    """Return all registered endpoint classes."""
-    return _endpoint_registry.copy()
+def endpoint(path: Optional[str] = None):
+    """Decorator to mark a method as a Jarvis endpoint.
+
+    The endpoint path is automatically derived from the method name unless
+    a custom path is provided.
+
+    Args:
+        path: Optional custom route path. Defaults to "/" + method name.
+
+    Returns:
+        A decorator function that marks the method as an endpoint.
+    """
+
+    def decorator(method: Callable) -> Callable:
+        @functools.wraps(method)
+        def wrapper(*args, **kwargs):
+            return method(*args, **kwargs)
+
+        wrapper._jarvis_endpoint = True
+        wrapper._jarvis_endpoint_path = path if path else f"/{method.__name__}"
+        return wrapper
+
+    return decorator
+
+
+def get_registered_apps() -> list[Type]:
+    """Return all registered app classes."""
+    return _app_registry.copy()
+
+
+def get_endpoint_methods(cls: Type) -> list[Callable]:
+    """Retrieve all endpoint-decorated methods from an app class.
+
+    Args:
+        cls: The app class to inspect.
+
+    Returns:
+        A list of methods that are decorated with @endpoint().
+    """
+    methods = []
+    for attr_name in dir(cls):
+        attr = getattr(cls, attr_name)
+        if callable(attr) and getattr(attr, "_jarvis_endpoint", False):
+            methods.append(attr)
+    return methods
 
 
 def clear_registry() -> None:
-    """Clear the endpoint registry. Useful for testing."""
-    _endpoint_registry.clear()
+    """Clear the app registry. Useful for testing."""
+    _app_registry.clear()

--- a/jarvis/decorator_test.py
+++ b/jarvis/decorator_test.py
@@ -1,73 +1,212 @@
-"""Unit tests for the endpoint decorator."""
+"""Unit tests for the app and endpoint decorators."""
 
 import jarvis
-from jarvis.decorator import clear_registry, get_registered_endpoints
+from jarvis.decorator import clear_registry, get_endpoint_methods, get_registered_apps
 
 
-def test_endpoint_decorator_sets_name():
-    """Test that the decorator sets _jarvis_endpoint_name on the class."""
-    clear_registry()
+class TestAppDecorator:
+    """Tests for the @jarvis.app() class decorator."""
 
-    @jarvis.endpoint()
-    class MyEndpoint:
-        pass
+    def test_app_decorator_sets_jarvis_app_flag(self):
+        """Test that the decorator sets _jarvis_app on the class."""
+        clear_registry()
 
-    assert hasattr(MyEndpoint, "_jarvis_endpoint_name")
-    assert MyEndpoint._jarvis_endpoint_name == "MyEndpoint"
+        @jarvis.app()
+        class MyApp:
+            pass
+
+        assert hasattr(MyApp, "_jarvis_app")
+        assert MyApp._jarvis_app is True
+
+    def test_app_decorator_sets_default_name(self):
+        """Test that the decorator sets _jarvis_app_name to class name by default."""
+        clear_registry()
+
+        @jarvis.app()
+        class MyApp:
+            pass
+
+        assert hasattr(MyApp, "_jarvis_app_name")
+        assert MyApp._jarvis_app_name == "MyApp"
+
+    def test_app_decorator_with_custom_name(self):
+        """Test that the decorator accepts a custom name."""
+        clear_registry()
+
+        @jarvis.app(name="CustomName")
+        class MyApp:
+            pass
+
+        assert MyApp._jarvis_app_name == "CustomName"
+
+    def test_app_decorator_registers_class(self):
+        """Test that the decorator registers the class in the registry."""
+        clear_registry()
+
+        @jarvis.app()
+        class MyApp:
+            pass
+
+        registered = get_registered_apps()
+        assert len(registered) == 1
+        assert registered[0] is MyApp
+
+    def test_multiple_apps_registered(self):
+        """Test that multiple apps can be registered."""
+        clear_registry()
+
+        @jarvis.app()
+        class FirstApp:
+            pass
+
+        @jarvis.app()
+        class SecondApp:
+            pass
+
+        registered = get_registered_apps()
+        assert len(registered) == 2
+        assert FirstApp in registered
+        assert SecondApp in registered
+
+    def test_app_decorator_returns_original_class(self):
+        """Test that the decorator returns the original class unchanged."""
+        clear_registry()
+
+        @jarvis.app()
+        class MyApp:
+            def helper(self):
+                return "hello"
+
+        instance = MyApp()
+        assert instance.helper() == "hello"
 
 
-def test_endpoint_decorator_registers_class():
-    """Test that the decorator registers the class in the registry."""
-    clear_registry()
+class TestEndpointDecorator:
+    """Tests for the @jarvis.endpoint() method decorator."""
 
-    @jarvis.endpoint()
-    class MyEndpoint:
-        pass
+    def test_endpoint_decorator_sets_flag(self):
+        """Test that the decorator sets _jarvis_endpoint on the method."""
+        clear_registry()
 
-    registered = get_registered_endpoints()
-    assert len(registered) == 1
-    assert registered[0] is MyEndpoint
+        @jarvis.app()
+        class MyApp:
+            @jarvis.endpoint()
+            def my_method(self):
+                pass
+
+        methods = get_endpoint_methods(MyApp)
+        assert len(methods) == 1
+        assert methods[0]._jarvis_endpoint is True
+
+    def test_endpoint_decorator_default_path(self):
+        """Test that the decorator sets default path from method name."""
+        clear_registry()
+
+        @jarvis.app()
+        class MyApp:
+            @jarvis.endpoint()
+            def add(self):
+                pass
+
+        methods = get_endpoint_methods(MyApp)
+        assert methods[0]._jarvis_endpoint_path == "/add"
+
+    def test_endpoint_decorator_custom_path(self):
+        """Test that the decorator accepts a custom path."""
+        clear_registry()
+
+        @jarvis.app()
+        class MyApp:
+            @jarvis.endpoint(path="/custom-path")
+            def my_method(self):
+                pass
+
+        methods = get_endpoint_methods(MyApp)
+        assert methods[0]._jarvis_endpoint_path == "/custom-path"
+
+    def test_multiple_endpoint_methods(self):
+        """Test that multiple methods can be decorated as endpoints."""
+        clear_registry()
+
+        @jarvis.app()
+        class MyApp:
+            @jarvis.endpoint()
+            def add(self):
+                pass
+
+            @jarvis.endpoint()
+            def subtract(self):
+                pass
+
+            @jarvis.endpoint(path="/mult")
+            def multiply(self):
+                pass
+
+        methods = get_endpoint_methods(MyApp)
+        assert len(methods) == 3
+
+        paths = {m._jarvis_endpoint_path for m in methods}
+        assert paths == {"/add", "/subtract", "/mult"}
+
+    def test_endpoint_preserves_method_name(self):
+        """Test that functools.wraps preserves method name."""
+        clear_registry()
+
+        @jarvis.app()
+        class MyApp:
+            @jarvis.endpoint()
+            def my_endpoint(self):
+                pass
+
+        methods = get_endpoint_methods(MyApp)
+        assert methods[0].__name__ == "my_endpoint"
+
+    def test_endpoint_preserves_docstring(self):
+        """Test that functools.wraps preserves docstring."""
+        clear_registry()
+
+        @jarvis.app()
+        class MyApp:
+            @jarvis.endpoint()
+            def my_endpoint(self):
+                """This is my docstring."""
+                pass
+
+        methods = get_endpoint_methods(MyApp)
+        assert methods[0].__doc__ == "This is my docstring."
+
+    def test_non_endpoint_methods_not_included(self):
+        """Test that non-decorated methods are not included."""
+        clear_registry()
+
+        @jarvis.app()
+        class MyApp:
+            @jarvis.endpoint()
+            def endpoint_method(self):
+                pass
+
+            def helper_method(self):
+                pass
+
+            def another_helper(self):
+                pass
+
+        methods = get_endpoint_methods(MyApp)
+        assert len(methods) == 1
+        assert methods[0].__name__ == "endpoint_method"
 
 
-def test_multiple_endpoints_registered():
-    """Test that multiple endpoints can be registered."""
-    clear_registry()
+class TestClearRegistry:
+    """Tests for the clear_registry function."""
 
-    @jarvis.endpoint()
-    class FirstEndpoint:
-        pass
+    def test_clear_registry_empties_apps(self):
+        """Test that clear_registry empties the app registry."""
+        clear_registry()
 
-    @jarvis.endpoint()
-    class SecondEndpoint:
-        pass
+        @jarvis.app()
+        class MyApp:
+            pass
 
-    registered = get_registered_endpoints()
-    assert len(registered) == 2
-    assert FirstEndpoint in registered
-    assert SecondEndpoint in registered
-
-
-def test_decorator_returns_original_class():
-    """Test that the decorator returns the original class unchanged."""
-    clear_registry()
-
-    @jarvis.endpoint()
-    class MyEndpoint:
-        def run(self):
-            return "hello"
-
-    instance = MyEndpoint()
-    assert instance.run() == "hello"
-
-
-def test_clear_registry():
-    """Test that clear_registry empties the registry."""
-    clear_registry()
-
-    @jarvis.endpoint()
-    class MyEndpoint:
-        pass
-
-    assert len(get_registered_endpoints()) == 1
-    clear_registry()
-    assert len(get_registered_endpoints()) == 0
+        assert len(get_registered_apps()) == 1
+        clear_registry()
+        assert len(get_registered_apps()) == 0

--- a/jarvis/integration_test.py
+++ b/jarvis/integration_test.py
@@ -1,4 +1,4 @@
-"""End-to-end integration tests."""
+"""End-to-end integration tests for multi-endpoint apps."""
 
 import pytest
 from fastapi.testclient import TestClient
@@ -9,152 +9,226 @@ from jarvis.decorator import clear_registry
 from jarvis.server import create_app
 
 
-class TestGreeterEndpoint:
-    """Integration test with the Greeter example from PRD."""
+class TestCalculatorApp:
+    """Integration test with the Calculator example from the issue."""
 
-    def test_greeter_example(self):
+    def test_calculator_multi_endpoint_example(self):
         clear_registry()
 
-        class Input(BaseModel):
-            name: str
+        class TwoNumbers(BaseModel):
+            a: int
+            b: int
 
-        class Output(BaseModel):
-            message: str
+        class Result(BaseModel):
+            result: int
 
-        @jarvis.endpoint()
-        class Greeter:
+        @jarvis.app()
+        class Calculator:
             def setup(self):
-                self.prefix = "Hello"
+                self.operation_count = 0
 
-            def run(self, input: Input) -> Output:
-                return Output(message=f"{self.prefix}, {input.name}!")
+            @jarvis.endpoint()
+            def add(self, input: TwoNumbers) -> Result:
+                self.operation_count += 1
+                return Result(result=input.a + input.b)
 
-        app = create_app(Greeter)
+            @jarvis.endpoint()
+            def subtract(self, input: TwoNumbers) -> Result:
+                self.operation_count += 1
+                return Result(result=input.a - input.b)
+
+        app = create_app(Calculator)
 
         with TestClient(app) as client:
-            # Test the endpoint
-            response = client.post("/", json={"name": "Vishnu"})
+            # Test add endpoint
+            response = client.post("/add", json={"a": 5, "b": 3})
             assert response.status_code == 200
-            assert response.json() == {"message": "Hello, Vishnu!"}
+            assert response.json() == {"result": 8}
+
+            # Test subtract endpoint
+            response = client.post("/subtract", json={"a": 10, "b": 4})
+            assert response.status_code == 200
+            assert response.json() == {"result": 6}
 
             # Verify OpenAPI docs
             response = client.get("/openapi.json")
             assert response.status_code == 200
-            assert response.json()["info"]["title"] == "Greeter"
+            openapi = response.json()
+            assert openapi["info"]["title"] == "Calculator"
+            assert "/add" in openapi["paths"]
+            assert "/subtract" in openapi["paths"]
 
-    def test_greeter_without_setup(self):
+
+class TestMLApp:
+    """Integration test with ML-like multi-endpoint app."""
+
+    def test_text_analysis_app(self):
         clear_registry()
 
-        class Input(BaseModel):
-            name: str
-
-        class Output(BaseModel):
-            message: str
-
-        @jarvis.endpoint()
-        class SimpleGreeter:
-            def run(self, input: Input) -> Output:
-                return Output(message=f"Hi, {input.name}!")
-
-        app = create_app(SimpleGreeter)
-
-        with TestClient(app) as client:
-            response = client.post("/", json={"name": "World"})
-            assert response.status_code == 200
-            assert response.json() == {"message": "Hi, World!"}
-
-
-class TestMLEndpoint:
-    """Integration test with ML-like endpoint (mocking the model)."""
-
-    def test_sentiment_analyzer(self):
-        clear_registry()
-
-        class SentimentInput(BaseModel):
+        class TextInput(BaseModel):
             text: str
 
         class SentimentOutput(BaseModel):
             label: str
             score: float
 
-        @jarvis.endpoint()
-        class SentimentAnalyzer:
-            def setup(self):
-                # Mock the ML pipeline
-                self.pipe = lambda text: [{"label": "POSITIVE", "score": 0.95}]
+        class LengthOutput(BaseModel):
+            length: int
+            word_count: int
 
-            def run(self, input: SentimentInput) -> SentimentOutput:
-                result = self.pipe(input.text)[0]
-                return SentimentOutput(
-                    label=result["label"],
-                    score=result["score"]
+        @jarvis.app()
+        class TextAnalyzer:
+            def setup(self):
+                # Mock ML model loading
+                self.sentiment_model = lambda text: ("POSITIVE", 0.95)
+                self.calls = 0
+
+            @jarvis.endpoint()
+            def analyze_sentiment(self, input: TextInput) -> SentimentOutput:
+                self.calls += 1
+                label, score = self.sentiment_model(input.text)
+                return SentimentOutput(label=label, score=score)
+
+            @jarvis.endpoint()
+            def get_length(self, input: TextInput) -> LengthOutput:
+                self.calls += 1
+                return LengthOutput(
+                    length=len(input.text),
+                    word_count=len(input.text.split())
                 )
 
-        app = create_app(SentimentAnalyzer)
+        app = create_app(TextAnalyzer)
 
         with TestClient(app) as client:
-            response = client.post("/", json={"text": "I love this product!"})
+            # Test sentiment analysis
+            response = client.post("/analyze_sentiment", json={"text": "I love this!"})
             assert response.status_code == 200
             data = response.json()
             assert data["label"] == "POSITIVE"
             assert data["score"] == 0.95
 
-    def test_text_classifier(self):
-        clear_registry()
-
-        class ClassifierInput(BaseModel):
-            text: str
-
-        class ClassifierOutput(BaseModel):
-            category: str
-            confidence: float
-
-        @jarvis.endpoint()
-        class TextClassifier:
-            def setup(self):
-                # Mock categories
-                self.categories = ["tech", "sports", "politics"]
-
-            def run(self, input: ClassifierInput) -> ClassifierOutput:
-                # Simple mock classification
-                if "python" in input.text.lower():
-                    return ClassifierOutput(category="tech", confidence=0.9)
-                return ClassifierOutput(category="general", confidence=0.5)
-
-        app = create_app(TextClassifier)
-
-        with TestClient(app) as client:
-            response = client.post("/", json={"text": "Python is great!"})
+            # Test length analysis
+            response = client.post("/get_length", json={"text": "Hello world"})
             assert response.status_code == 200
             data = response.json()
-            assert data["category"] == "tech"
-            assert data["confidence"] == 0.9
+            assert data["length"] == 11
+            assert data["word_count"] == 2
 
 
-class TestEndpointCodeLines:
-    """Verify success criteria: endpoint defined in <10 lines."""
+class TestSharedStateIntegration:
+    """Integration tests for shared state across endpoints."""
 
-    def test_minimal_endpoint(self):
-        """Demonstrate that a functional endpoint can be defined in under 10 lines."""
+    def test_ml_model_shared_across_endpoints(self):
+        """Simulate an ML app where a model is loaded once and used by multiple endpoints."""
         clear_registry()
 
-        # Lines 1-2: Pydantic models
+        class Input(BaseModel):
+            value: float
+
+        class PredictionOutput(BaseModel):
+            prediction: float
+
+        class ModelInfoOutput(BaseModel):
+            model_name: str
+            predictions_made: int
+
+        @jarvis.app()
+        class MLService:
+            def setup(self):
+                # Simulate loading a heavy ML model
+                self.model_name = "linear_model_v1"
+                self.weight = 2.5
+                self.bias = 1.0
+                self.predictions_made = 0
+
+            @jarvis.endpoint()
+            def predict(self, input: Input) -> PredictionOutput:
+                self.predictions_made += 1
+                prediction = input.value * self.weight + self.bias
+                return PredictionOutput(prediction=prediction)
+
+            @jarvis.endpoint()
+            def model_info(self, input: Input) -> ModelInfoOutput:
+                return ModelInfoOutput(
+                    model_name=self.model_name,
+                    predictions_made=self.predictions_made
+                )
+
+        app = create_app(MLService)
+
+        with TestClient(app) as client:
+            # Make several predictions
+            for x in [1.0, 2.0, 3.0]:
+                response = client.post("/predict", json={"value": x})
+                assert response.status_code == 200
+
+            # Check model info reflects all predictions
+            response = client.post("/model_info", json={"value": 0})
+            assert response.status_code == 200
+            data = response.json()
+            assert data["model_name"] == "linear_model_v1"
+            assert data["predictions_made"] == 3
+
+
+class TestCustomPaths:
+    """Integration tests for custom endpoint paths."""
+
+    def test_custom_path_routing(self):
+        clear_registry()
+
+        class NumberInput(BaseModel):
+            n: int
+
+        class NumberOutput(BaseModel):
+            result: int
+
+        @jarvis.app()
+        class MathOperations:
+            @jarvis.endpoint(path="/v1/double")
+            def double(self, input: NumberInput) -> NumberOutput:
+                return NumberOutput(result=input.n * 2)
+
+            @jarvis.endpoint(path="/v1/triple")
+            def triple(self, input: NumberInput) -> NumberOutput:
+                return NumberOutput(result=input.n * 3)
+
+            @jarvis.endpoint(path="/v2/quadruple")
+            def quadruple(self, input: NumberInput) -> NumberOutput:
+                return NumberOutput(result=input.n * 4)
+
+        app = create_app(MathOperations)
+
+        with TestClient(app) as client:
+            assert client.post("/v1/double", json={"n": 5}).json() == {"result": 10}
+            assert client.post("/v1/triple", json={"n": 5}).json() == {"result": 15}
+            assert client.post("/v2/quadruple", json={"n": 5}).json() == {"result": 20}
+
+
+class TestMinimalApp:
+    """Verify success criteria: endpoint defined in minimal lines."""
+
+    def test_minimal_multi_endpoint_app(self):
+        """Demonstrate that a functional multi-endpoint app can be concise."""
+        clear_registry()
+
         class In(BaseModel):
             x: int
 
         class Out(BaseModel):
             y: int
 
-        # Lines 3-6: Endpoint class (4 lines)
-        @jarvis.endpoint()
-        class Doubler:
-            def run(self, input: In) -> Out:
-                return Out(y=input.x * 2)
+        @jarvis.app()
+        class Math:
+            @jarvis.endpoint()
+            def double(self, i: In) -> Out:
+                return Out(y=i.x * 2)
 
-        # Total: 6 lines for a functional endpoint
-        app = create_app(Doubler)
+            @jarvis.endpoint()
+            def square(self, i: In) -> Out:
+                return Out(y=i.x ** 2)
+
+        app = create_app(Math)
 
         with TestClient(app) as client:
-            response = client.post("/", json={"x": 5})
-            assert response.status_code == 200
-            assert response.json() == {"y": 10}
+            assert client.post("/double", json={"x": 5}).json() == {"y": 10}
+            assert client.post("/square", json={"x": 4}).json() == {"y": 16}

--- a/jarvis/server.py
+++ b/jarvis/server.py
@@ -1,63 +1,84 @@
-"""FastAPI server integration for Jarvis endpoints."""
+"""FastAPI server integration for Jarvis apps."""
 
 from contextlib import asynccontextmanager
-from typing import Type
+from typing import Callable, Type
 
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 
+from jarvis.decorator import get_endpoint_methods
 from jarvis.exceptions import EndpointSetupError
-from jarvis.validator import get_input_type, get_output_type, validate_endpoint
+from jarvis.validator import get_method_input_type, get_method_output_type, validate_app
 
 
-def create_app(endpoint_cls: Type) -> FastAPI:
-    """Create a FastAPI app from an endpoint class.
+def create_app(app_cls: Type) -> FastAPI:
+    """Create a FastAPI app from a Jarvis app class.
 
     Args:
-        endpoint_cls: The endpoint class decorated with @jarvis.endpoint().
+        app_cls: The app class decorated with @jarvis.app().
 
     Returns:
-        A configured FastAPI application.
+        A configured FastAPI application with routes for all endpoints.
 
     Raises:
-        EndpointValidationError: If the endpoint class is invalid.
+        EndpointValidationError: If the app class is invalid.
         EndpointSetupError: If the setup() method fails.
     """
-    validate_endpoint(endpoint_cls)
+    validate_app(app_cls)
 
-    endpoint_name = getattr(endpoint_cls, "_jarvis_endpoint_name", "endpoint")
-    input_type = get_input_type(endpoint_cls)
-    output_type = get_output_type(endpoint_cls)
+    app_name = getattr(app_cls, "_jarvis_app_name", "app")
+    endpoint_methods = get_endpoint_methods(app_cls)
+
+    # Create the app instance once - shared across all endpoints
+    app_instance = app_cls()
 
     @asynccontextmanager
     async def lifespan(app: FastAPI):
-        # Instantiate the endpoint class
-        endpoint_instance = endpoint_cls()
-
         # Call setup() if it exists
-        if hasattr(endpoint_instance, "setup") and callable(endpoint_instance.setup):
+        if hasattr(app_instance, "setup") and callable(app_instance.setup):
             try:
-                endpoint_instance.setup()
+                app_instance.setup()
             except Exception as e:
                 raise EndpointSetupError(f"setup() failed: {e}") from e
 
-        # Store instance in app state for access in routes
-        app.state.endpoint_instance = endpoint_instance
-
         yield
 
-    app = FastAPI(title=endpoint_name, lifespan=lifespan)
+    fastapi_app = FastAPI(title=app_name, lifespan=lifespan)
 
-    @app.post("/", response_model=output_type)
-    async def run_endpoint(request: Request, input_data: input_type) -> output_type:
-        """Handle incoming requests by calling the endpoint's run() method."""
-        instance = request.app.state.endpoint_instance
-        try:
-            return instance.run(input_data)
-        except Exception as e:
-            return JSONResponse(
-                status_code=500,
-                content={"detail": str(e)},
-            )
+    # Register a POST route for each endpoint method
+    for method in endpoint_methods:
+        _register_endpoint_route(fastapi_app, method, app_instance)
 
-    return app
+    return fastapi_app
+
+
+def _register_endpoint_route(fastapi_app: FastAPI, method: Callable, app_instance: object) -> None:
+    """Register a POST route for an endpoint method.
+
+    Args:
+        fastapi_app: The FastAPI application to register the route on.
+        method: The endpoint method to create a route for.
+        app_instance: The shared app instance to call methods on.
+    """
+    path = method._jarvis_endpoint_path
+    input_type = get_method_input_type(method)
+    output_type = get_method_output_type(method)
+    method_name = method.__name__
+
+    # Create the route handler
+    # We need to capture method_name and app_instance in closure
+    def create_handler(captured_method_name: str, captured_instance: object):
+        async def handler(input_data: input_type) -> output_type:
+            """Handle incoming requests by calling the endpoint method."""
+            endpoint_method = getattr(captured_instance, captured_method_name)
+            try:
+                return endpoint_method(input_data)
+            except Exception as e:
+                return JSONResponse(
+                    status_code=500,
+                    content={"detail": str(e)},
+                )
+        return handler
+
+    # Register the route with FastAPI
+    fastapi_app.post(path, response_model=output_type)(create_handler(method_name, app_instance))

--- a/jarvis/validator_test.py
+++ b/jarvis/validator_test.py
@@ -1,197 +1,380 @@
-"""Unit tests for endpoint validation logic."""
+"""Unit tests for app and endpoint validation logic."""
 
 import pytest
 from pydantic import BaseModel
 
+import jarvis
+from jarvis.decorator import clear_registry
 from jarvis.exceptions import EndpointValidationError
 from jarvis.validator import (
-    get_input_type,
-    get_output_type,
-    validate_endpoint,
-    validate_has_run_method,
-    validate_input_is_pydantic_model,
-    validate_output_is_pydantic_model,
-    validate_run_type_hints,
+    get_method_input_type,
+    get_method_output_type,
+    validate_app,
+    validate_has_endpoint_methods,
+    validate_is_jarvis_app,
+    validate_method_input_is_pydantic_model,
+    validate_method_output_is_pydantic_model,
+    validate_method_type_hints,
+    validate_no_duplicate_paths,
 )
 
 
 class Input(BaseModel):
-    name: str
+    value: int
 
 
 class Output(BaseModel):
-    message: str
+    result: int
 
 
-class TestValidateHasRunMethod:
-    def test_valid_class_with_run_method(self):
-        class ValidEndpoint:
-            def run(self, input: Input) -> Output:
+class TestValidateIsJarvisApp:
+    """Tests for validate_is_jarvis_app function."""
+
+    def test_valid_app_class(self):
+        clear_registry()
+
+        @jarvis.app()
+        class ValidApp:
+            @jarvis.endpoint()
+            def my_method(self, input: Input) -> Output:
                 pass
 
-        validate_has_run_method(ValidEndpoint)
+        validate_is_jarvis_app(ValidApp)
 
-    def test_missing_run_method(self):
-        class InvalidEndpoint:
+    def test_class_without_app_decorator(self):
+        class NotAnApp:
             pass
 
         with pytest.raises(EndpointValidationError) as exc_info:
-            validate_has_run_method(InvalidEndpoint)
-        assert "must define a run() method" in str(exc_info.value)
-
-    def test_run_is_not_callable(self):
-        class InvalidEndpoint:
-            run = "not a method"
-
-        with pytest.raises(EndpointValidationError) as exc_info:
-            validate_has_run_method(InvalidEndpoint)
-        assert "must define a run() method" in str(exc_info.value)
+            validate_is_jarvis_app(NotAnApp)
+        assert "must be decorated with @jarvis.app()" in str(exc_info.value)
 
 
-class TestValidateRunTypeHints:
-    def test_valid_type_hints(self):
-        class ValidEndpoint:
-            def run(self, input: Input) -> Output:
+class TestValidateHasEndpointMethods:
+    """Tests for validate_has_endpoint_methods function."""
+
+    def test_app_with_endpoints(self):
+        clear_registry()
+
+        @jarvis.app()
+        class ValidApp:
+            @jarvis.endpoint()
+            def my_method(self, input: Input) -> Output:
                 pass
 
-        validate_run_type_hints(ValidEndpoint)
+        validate_has_endpoint_methods(ValidApp)
+
+    def test_app_without_endpoints(self):
+        clear_registry()
+
+        @jarvis.app()
+        class EmptyApp:
+            def helper(self):
+                pass
+
+        with pytest.raises(EndpointValidationError) as exc_info:
+            validate_has_endpoint_methods(EmptyApp)
+        assert "must have at least one method decorated with @jarvis.endpoint()" in str(
+            exc_info.value
+        )
+
+
+class TestValidateMethodTypeHints:
+    """Tests for validate_method_type_hints function."""
+
+    def test_valid_type_hints(self):
+        clear_registry()
+
+        @jarvis.app()
+        class ValidApp:
+            @jarvis.endpoint()
+            def my_method(self, input: Input) -> Output:
+                pass
+
+        from jarvis.decorator import get_endpoint_methods
+
+        methods = get_endpoint_methods(ValidApp)
+        validate_method_type_hints(methods[0])
 
     def test_missing_input_type_hint(self):
-        class InvalidEndpoint:
-            def run(self, input) -> Output:
+        clear_registry()
+
+        @jarvis.app()
+        class InvalidApp:
+            @jarvis.endpoint()
+            def my_method(self, input) -> Output:
                 pass
 
+        from jarvis.decorator import get_endpoint_methods
+
+        methods = get_endpoint_methods(InvalidApp)
         with pytest.raises(EndpointValidationError) as exc_info:
-            validate_run_type_hints(InvalidEndpoint)
-        assert "must have type hints for input and output" in str(exc_info.value)
+            validate_method_type_hints(methods[0])
+        assert "must have a type hint for input parameter" in str(exc_info.value)
 
     def test_missing_return_type_hint(self):
-        class InvalidEndpoint:
-            def run(self, input: Input):
+        clear_registry()
+
+        @jarvis.app()
+        class InvalidApp:
+            @jarvis.endpoint()
+            def my_method(self, input: Input):
                 pass
 
-        with pytest.raises(EndpointValidationError) as exc_info:
-            validate_run_type_hints(InvalidEndpoint)
-        assert "must have type hints for input and output" in str(exc_info.value)
+        from jarvis.decorator import get_endpoint_methods
 
-    def test_missing_both_type_hints(self):
-        class InvalidEndpoint:
-            def run(self, input):
-                pass
-
+        methods = get_endpoint_methods(InvalidApp)
         with pytest.raises(EndpointValidationError) as exc_info:
-            validate_run_type_hints(InvalidEndpoint)
-        assert "must have type hints for input and output" in str(exc_info.value)
+            validate_method_type_hints(methods[0])
+        assert "must have a return type hint" in str(exc_info.value)
 
     def test_no_input_parameter(self):
-        class InvalidEndpoint:
-            def run(self) -> Output:
+        clear_registry()
+
+        @jarvis.app()
+        class InvalidApp:
+            @jarvis.endpoint()
+            def my_method(self) -> Output:
                 pass
 
+        from jarvis.decorator import get_endpoint_methods
+
+        methods = get_endpoint_methods(InvalidApp)
         with pytest.raises(EndpointValidationError) as exc_info:
-            validate_run_type_hints(InvalidEndpoint)
-        assert "must have type hints for input and output" in str(exc_info.value)
+            validate_method_type_hints(methods[0])
+        assert "must accept an input parameter" in str(exc_info.value)
 
 
-class TestValidateInputIsPydanticModel:
+class TestValidateMethodInputIsPydanticModel:
+    """Tests for validate_method_input_is_pydantic_model function."""
+
     def test_valid_pydantic_input(self):
-        class ValidEndpoint:
-            def run(self, input: Input) -> Output:
+        clear_registry()
+
+        @jarvis.app()
+        class ValidApp:
+            @jarvis.endpoint()
+            def my_method(self, input: Input) -> Output:
                 pass
 
-        validate_input_is_pydantic_model(ValidEndpoint)
+        from jarvis.decorator import get_endpoint_methods
+
+        methods = get_endpoint_methods(ValidApp)
+        validate_method_input_is_pydantic_model(methods[0])
 
     def test_input_is_not_pydantic_model(self):
-        class InvalidEndpoint:
-            def run(self, input: str) -> Output:
+        clear_registry()
+
+        @jarvis.app()
+        class InvalidApp:
+            @jarvis.endpoint()
+            def my_method(self, input: str) -> Output:
                 pass
 
+        from jarvis.decorator import get_endpoint_methods
+
+        methods = get_endpoint_methods(InvalidApp)
         with pytest.raises(EndpointValidationError) as exc_info:
-            validate_input_is_pydantic_model(InvalidEndpoint)
-        assert "Input type must be a Pydantic BaseModel subclass" in str(exc_info.value)
+            validate_method_input_is_pydantic_model(methods[0])
+        assert "input type must be a Pydantic BaseModel subclass" in str(exc_info.value)
 
     def test_input_is_dict(self):
-        class InvalidEndpoint:
-            def run(self, input: dict) -> Output:
+        clear_registry()
+
+        @jarvis.app()
+        class InvalidApp:
+            @jarvis.endpoint()
+            def my_method(self, input: dict) -> Output:
                 pass
 
+        from jarvis.decorator import get_endpoint_methods
+
+        methods = get_endpoint_methods(InvalidApp)
         with pytest.raises(EndpointValidationError) as exc_info:
-            validate_input_is_pydantic_model(InvalidEndpoint)
-        assert "Input type must be a Pydantic BaseModel subclass" in str(exc_info.value)
+            validate_method_input_is_pydantic_model(methods[0])
+        assert "input type must be a Pydantic BaseModel subclass" in str(exc_info.value)
 
 
-class TestValidateOutputIsPydanticModel:
+class TestValidateMethodOutputIsPydanticModel:
+    """Tests for validate_method_output_is_pydantic_model function."""
+
     def test_valid_pydantic_output(self):
-        class ValidEndpoint:
-            def run(self, input: Input) -> Output:
+        clear_registry()
+
+        @jarvis.app()
+        class ValidApp:
+            @jarvis.endpoint()
+            def my_method(self, input: Input) -> Output:
                 pass
 
-        validate_output_is_pydantic_model(ValidEndpoint)
+        from jarvis.decorator import get_endpoint_methods
+
+        methods = get_endpoint_methods(ValidApp)
+        validate_method_output_is_pydantic_model(methods[0])
 
     def test_output_is_not_pydantic_model(self):
-        class InvalidEndpoint:
-            def run(self, input: Input) -> str:
+        clear_registry()
+
+        @jarvis.app()
+        class InvalidApp:
+            @jarvis.endpoint()
+            def my_method(self, input: Input) -> str:
                 pass
 
+        from jarvis.decorator import get_endpoint_methods
+
+        methods = get_endpoint_methods(InvalidApp)
         with pytest.raises(EndpointValidationError) as exc_info:
-            validate_output_is_pydantic_model(InvalidEndpoint)
-        assert "Output type must be a Pydantic BaseModel subclass" in str(exc_info.value)
+            validate_method_output_is_pydantic_model(methods[0])
+        assert "return type must be a Pydantic BaseModel subclass" in str(exc_info.value)
 
     def test_output_is_dict(self):
-        class InvalidEndpoint:
-            def run(self, input: Input) -> dict:
+        clear_registry()
+
+        @jarvis.app()
+        class InvalidApp:
+            @jarvis.endpoint()
+            def my_method(self, input: Input) -> dict:
+                pass
+
+        from jarvis.decorator import get_endpoint_methods
+
+        methods = get_endpoint_methods(InvalidApp)
+        with pytest.raises(EndpointValidationError) as exc_info:
+            validate_method_output_is_pydantic_model(methods[0])
+        assert "return type must be a Pydantic BaseModel subclass" in str(exc_info.value)
+
+
+class TestValidateNoDuplicatePaths:
+    """Tests for validate_no_duplicate_paths function."""
+
+    def test_unique_paths(self):
+        clear_registry()
+
+        @jarvis.app()
+        class ValidApp:
+            @jarvis.endpoint()
+            def add(self, input: Input) -> Output:
+                pass
+
+            @jarvis.endpoint()
+            def subtract(self, input: Input) -> Output:
+                pass
+
+        validate_no_duplicate_paths(ValidApp)
+
+    def test_duplicate_default_paths(self):
+        """This shouldn't happen in practice since method names must be unique."""
+        pass  # Method names are unique by Python rules
+
+    def test_duplicate_custom_paths(self):
+        clear_registry()
+
+        @jarvis.app()
+        class InvalidApp:
+            @jarvis.endpoint(path="/same")
+            def method1(self, input: Input) -> Output:
+                pass
+
+            @jarvis.endpoint(path="/same")
+            def method2(self, input: Input) -> Output:
                 pass
 
         with pytest.raises(EndpointValidationError) as exc_info:
-            validate_output_is_pydantic_model(InvalidEndpoint)
-        assert "Output type must be a Pydantic BaseModel subclass" in str(exc_info.value)
+            validate_no_duplicate_paths(InvalidApp)
+        assert "Duplicate endpoint path '/same'" in str(exc_info.value)
 
 
-class TestValidateEndpoint:
-    def test_valid_endpoint(self):
-        class ValidEndpoint:
-            def run(self, input: Input) -> Output:
-                pass
+class TestValidateApp:
+    """Tests for the main validate_app function."""
 
-        validate_endpoint(ValidEndpoint)
+    def test_valid_app(self):
+        clear_registry()
 
-    def test_valid_endpoint_with_setup(self):
-        class ValidEndpoint:
+        @jarvis.app()
+        class ValidApp:
+            @jarvis.endpoint()
+            def add(self, input: Input) -> Output:
+                return Output(result=input.value + 1)
+
+            @jarvis.endpoint()
+            def subtract(self, input: Input) -> Output:
+                return Output(result=input.value - 1)
+
+        validate_app(ValidApp)
+
+    def test_valid_app_with_setup(self):
+        clear_registry()
+
+        @jarvis.app()
+        class ValidApp:
             def setup(self):
+                self.multiplier = 2
+
+            @jarvis.endpoint()
+            def multiply(self, input: Input) -> Output:
+                return Output(result=input.value * self.multiplier)
+
+        validate_app(ValidApp)
+
+    def test_invalid_app_not_decorated(self):
+        class NotAnApp:
+            def method(self, input: Input) -> Output:
                 pass
 
-            def run(self, input: Input) -> Output:
-                pass
+        with pytest.raises(EndpointValidationError):
+            validate_app(NotAnApp)
 
-        validate_endpoint(ValidEndpoint)
+    def test_invalid_app_no_endpoints(self):
+        clear_registry()
 
-    def test_invalid_endpoint_no_run(self):
-        class InvalidEndpoint:
+        @jarvis.app()
+        class EmptyApp:
             pass
 
         with pytest.raises(EndpointValidationError):
-            validate_endpoint(InvalidEndpoint)
+            validate_app(EmptyApp)
 
-    def test_invalid_endpoint_no_type_hints(self):
-        class InvalidEndpoint:
-            def run(self, input):
+    def test_invalid_app_bad_type_hints(self):
+        clear_registry()
+
+        @jarvis.app()
+        class InvalidApp:
+            @jarvis.endpoint()
+            def my_method(self, input: str) -> str:
                 pass
 
         with pytest.raises(EndpointValidationError):
-            validate_endpoint(InvalidEndpoint)
+            validate_app(InvalidApp)
 
 
-class TestGetInputOutputTypes:
-    def test_get_input_type(self):
-        class MyEndpoint:
-            def run(self, input: Input) -> Output:
+class TestGetMethodTypes:
+    """Tests for get_method_input_type and get_method_output_type functions."""
+
+    def test_get_method_input_type(self):
+        clear_registry()
+
+        @jarvis.app()
+        class MyApp:
+            @jarvis.endpoint()
+            def my_method(self, input: Input) -> Output:
                 pass
 
-        assert get_input_type(MyEndpoint) is Input
+        from jarvis.decorator import get_endpoint_methods
 
-    def test_get_output_type(self):
-        class MyEndpoint:
-            def run(self, input: Input) -> Output:
+        methods = get_endpoint_methods(MyApp)
+        assert get_method_input_type(methods[0]) is Input
+
+    def test_get_method_output_type(self):
+        clear_registry()
+
+        @jarvis.app()
+        class MyApp:
+            @jarvis.endpoint()
+            def my_method(self, input: Input) -> Output:
                 pass
 
-        assert get_output_type(MyEndpoint) is Output
+        from jarvis.decorator import get_endpoint_methods
+
+        methods = get_endpoint_methods(MyApp)
+        assert get_method_output_type(methods[0]) is Output

--- a/tasks/tasks-multi-endpoint-support.md
+++ b/tasks/tasks-multi-endpoint-support.md
@@ -1,0 +1,88 @@
+## Relevant Files
+
+- `jarvis/decorator.py` - Contains the decorator implementations; needs new `app()` decorator and method-level `endpoint()` decorator
+- `jarvis/decorator_test.py` - Unit tests for decorator functionality
+- `jarvis/validator.py` - Validation logic; needs updates to validate method-level endpoints
+- `jarvis/validator_test.py` - Unit tests for validation logic
+- `jarvis/server.py` - FastAPI server integration; needs multi-route registration support
+- `jarvis/server_test.py` - Unit tests for server functionality
+- `jarvis/cli.py` - CLI implementation; needs updated messaging for multi-endpoint apps
+- `jarvis/cli_test.py` - Unit tests for CLI
+- `jarvis/exceptions.py` - Custom exceptions; may need new exception types
+- `jarvis/__init__.py` - Package exports; needs to export new `app` decorator
+- `jarvis/integration_test.py` - Integration tests for end-to-end scenarios
+- `example_app.py` - Example app; update to demonstrate multi-endpoint usage
+
+### Notes
+
+- Unit tests should typically be placed alongside the code files they are testing (e.g., `decorator.py` and `decorator_test.py` in the same directory).
+- Use `pytest` to run tests: `pytest jarvis/` or `pytest jarvis/decorator_test.py` for specific files.
+- The current branch is `feature/jarvis-sdk-v0` - no need to create a new feature branch.
+- **Backward compatibility is NOT required** - the old single-endpoint `@endpoint()` class decorator will be removed entirely.
+
+## Instructions for Completing Tasks
+
+**IMPORTANT:** As you complete each task, you must check it off in this markdown file by changing `- [ ]` to `- [x]`. This helps track progress and ensures you don't skip any steps.
+
+Example:
+- `- [ ] 1.1 Read file` → `- [x] 1.1 Read file` (after completing)
+
+Update the file after completing each sub-task, not just after completing an entire parent task.
+
+## Tasks
+
+- [x] 1.0 Implement the `@jarvis.app()` class decorator
+  - [x] 1.1 Remove the old class-level `endpoint()` decorator from `decorator.py`
+  - [x] 1.2 Remove `_endpoint_registry` and replace with `_app_registry`
+  - [x] 1.3 Add new `app()` decorator function that marks a class as a Jarvis app
+  - [x] 1.4 Store app metadata on the class (e.g., `_jarvis_app = True`, `_jarvis_app_name`)
+  - [x] 1.5 Rename `get_registered_endpoints()` to `get_registered_apps()`
+
+- [x] 2.0 Implement the `@jarvis.endpoint()` method-level decorator
+  - [x] 2.1 Create new `endpoint()` decorator that works on methods (not classes)
+  - [x] 2.2 Mark decorated methods with `_jarvis_endpoint = True` and store route path
+  - [x] 2.3 Add optional `path` parameter to `endpoint()` for custom route paths (defaults to method name)
+  - [x] 2.4 Create helper function `get_endpoint_methods(cls)` to retrieve all endpoint-decorated methods from an app class
+  - [x] 2.5 Ensure method-level decorator preserves method signature and docstrings using `functools.wraps`
+
+- [x] 3.0 Update validation logic for multi-endpoint apps
+  - [x] 3.1 Remove old `validate_endpoint()`, `validate_has_run_method()`, `validate_run_type_hints()` functions
+  - [x] 3.2 Remove old `get_input_type()` and `get_output_type()` functions
+  - [x] 3.3 Create new `validate_app()` function for validating app-decorated classes
+  - [x] 3.4 Validate that app classes have at least one `@endpoint()` decorated method
+  - [x] 3.5 For each endpoint method, validate input parameter has Pydantic BaseModel type hint
+  - [x] 3.6 For each endpoint method, validate return type is a Pydantic BaseModel subclass
+  - [x] 3.7 Add `get_method_input_type(method)` and `get_method_output_type(method)` helper functions
+  - [x] 3.8 Validate that endpoint routes don't conflict (no duplicate paths)
+
+- [x] 4.0 Update server to handle multi-route registration
+  - [x] 4.1 Remove old `create_app()` implementation that expects a `run()` method
+  - [x] 4.2 Create new `create_app()` that works with `@app()` decorated classes
+  - [x] 4.3 Implement single app instance creation with shared state across all endpoints
+  - [x] 4.4 Call `setup()` method once during lifespan startup if it exists
+  - [x] 4.5 Register a POST route for each `@endpoint()` decorated method (e.g., `POST /add`, `POST /subtract`)
+  - [x] 4.6 Each route handler should call the corresponding method on the shared instance
+
+- [x] 5.0 Update CLI messaging and multi-endpoint handling
+  - [x] 5.1 Update `dev` command to use `get_registered_apps()` instead of `get_registered_endpoints()`
+  - [x] 5.2 Print all available routes on startup (e.g., "Endpoints: POST /add, POST /subtract")
+  - [x] 5.3 Update error messages to reference `@jarvis.app()` and `@jarvis.endpoint()` decorators
+
+- [x] 6.0 Update test coverage
+  - [x] 6.1 Remove old class-level `@endpoint()` tests from `decorator_test.py`
+  - [x] 6.2 Add tests for `@app()` decorator registration and metadata in `decorator_test.py`
+  - [x] 6.3 Add tests for method-level `@endpoint()` decorator in `decorator_test.py`
+  - [x] 6.4 Add tests for custom route paths via `@endpoint(path="/custom")` in `decorator_test.py`
+  - [x] 6.5 Remove old `run()` method validation tests from `validator_test.py`
+  - [x] 6.6 Add validation tests for multi-endpoint apps in `validator_test.py`
+  - [x] 6.7 Add tests for missing/invalid Pydantic models on endpoint methods in `validator_test.py`
+  - [x] 6.8 Remove old single-endpoint server tests from `server_test.py`
+  - [x] 6.9 Add server tests for multi-route registration in `server_test.py`
+  - [x] 6.10 Add tests verifying shared state across endpoints in `server_test.py`
+  - [x] 6.11 Update integration tests in `integration_test.py` for multi-endpoint app lifecycle
+  - [x] 6.12 Update CLI tests in `cli_test.py` for new decorator pattern
+
+- [x] 7.0 Update exports and documentation
+  - [x] 7.1 Update `jarvis/__init__.py` to export both `app` and `endpoint` decorators
+  - [x] 7.2 Update `example_app.py` to demonstrate multi-endpoint Calculator example from the issue
+  - [x] 7.3 Ensure all new public functions have proper docstrings


### PR DESCRIPTION
## Summary

- Replace class-level `@endpoint()` with `@app()` class decorator
- Add method-level `@endpoint()` decorator for multiple routes per class
- Support shared state across endpoints via `setup()` method
- Validate Pydantic models for all endpoint inputs/outputs
- Register multiple POST routes from single app class
- Update CLI messaging for multi-endpoint apps

## Changes

- **jarvis/decorator.py**: New `@app()` class decorator and method-level `@endpoint()` decorator
- **jarvis/validator.py**: Updated validation for multi-endpoint apps
- **jarvis/server.py**: Multi-route registration support
- **jarvis/cli.py**: Updated messaging for multi-endpoint apps
- **example_app.py**: Updated to demonstrate multi-endpoint usage

## Test plan

- [x] All 71 tests pass (`pytest jarvis/`)
- [x] Verified multi-endpoint example app works correctly
- [x] Validated OpenAPI docs show all endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)