### PR TITLE
Simplify to single-app architecture for ML inference

### DIFF
--- a/jarvis/cli_test.py
+++ b/jarvis/cli_test.py
@@ -100,7 +100,7 @@ class TestDevCommandValidation:
         import importlib.util
         import sys
 
-        from jarvis.decorator import clear_registry, get_endpoint_methods, get_registered_apps
+        from jarvis.decorator import _reset_registry, get_endpoint_methods, get_registered_app
 
         with tempfile.NamedTemporaryFile(suffix=".py", delete=False) as f:
             code = b"""
@@ -127,17 +127,17 @@ class Calculator:
             temp_path = f.name
 
         try:
-            clear_registry()
+            _reset_registry()
             spec = importlib.util.spec_from_file_location("test_module", temp_path)
             module = importlib.util.module_from_spec(spec)
             sys.modules["test_module"] = module
             spec.loader.exec_module(module)
 
-            apps = get_registered_apps()
-            assert len(apps) == 1
-            assert apps[0]._jarvis_app_name == "Calculator"
+            app_cls = get_registered_app()
+            assert app_cls is not None
+            assert app_cls._jarvis_app_name == "Calculator"
 
-            methods = get_endpoint_methods(apps[0])
+            methods = get_endpoint_methods(app_cls)
             assert len(methods) == 2
         finally:
             Path(temp_path).unlink()

--- a/jarvis/exceptions.py
+++ b/jarvis/exceptions.py
@@ -17,3 +17,9 @@ class EndpointSetupError(JarvisError):
     """Raised when an endpoint's setup() method fails."""
 
     pass
+
+
+class MultipleAppsError(JarvisError):
+    """Raised when multiple @jarvis.app() classes are defined in a module."""
+
+    pass

--- a/jarvis/integration_test.py
+++ b/jarvis/integration_test.py
@@ -5,7 +5,7 @@ from fastapi.testclient import TestClient
 from pydantic import BaseModel
 
 import jarvis
-from jarvis.decorator import clear_registry
+from jarvis.decorator import _reset_registry
 from jarvis.server import create_app
 
 
@@ -13,7 +13,7 @@ class TestCalculatorApp:
     """Integration test with the Calculator example from the issue."""
 
     def test_calculator_multi_endpoint_example(self):
-        clear_registry()
+        _reset_registry()
 
         class TwoNumbers(BaseModel):
             a: int
@@ -63,7 +63,7 @@ class TestMLApp:
     """Integration test with ML-like multi-endpoint app."""
 
     def test_text_analysis_app(self):
-        clear_registry()
+        _reset_registry()
 
         class TextInput(BaseModel):
             text: str
@@ -120,7 +120,7 @@ class TestSharedStateIntegration:
 
     def test_ml_model_shared_across_endpoints(self):
         """Simulate an ML app where a model is loaded once and used by multiple endpoints."""
-        clear_registry()
+        _reset_registry()
 
         class Input(BaseModel):
             value: float
@@ -174,7 +174,7 @@ class TestCustomPaths:
     """Integration tests for custom endpoint paths."""
 
     def test_custom_path_routing(self):
-        clear_registry()
+        _reset_registry()
 
         class NumberInput(BaseModel):
             n: int
@@ -209,7 +209,7 @@ class TestMinimalApp:
 
     def test_minimal_multi_endpoint_app(self):
         """Demonstrate that a functional multi-endpoint app can be concise."""
-        clear_registry()
+        _reset_registry()
 
         class In(BaseModel):
             x: int

--- a/jarvis/server_test.py
+++ b/jarvis/server_test.py
@@ -5,7 +5,7 @@ from fastapi.testclient import TestClient
 from pydantic import BaseModel
 
 import jarvis
-from jarvis.decorator import clear_registry
+from jarvis.decorator import _reset_registry
 from jarvis.exceptions import EndpointSetupError, EndpointValidationError
 from jarvis.server import create_app
 
@@ -31,7 +31,7 @@ class TestCreateApp:
     """Tests for creating FastAPI apps from Jarvis app classes."""
 
     def test_creates_fastapi_app(self):
-        clear_registry()
+        _reset_registry()
 
         @jarvis.app()
         class MyApp:
@@ -43,7 +43,7 @@ class TestCreateApp:
         assert app is not None
 
     def test_uses_app_name_as_title(self):
-        clear_registry()
+        _reset_registry()
 
         @jarvis.app(name="Calculator")
         class MyApp:
@@ -55,7 +55,7 @@ class TestCreateApp:
         assert app.title == "Calculator"
 
     def test_uses_class_name_as_default_title(self):
-        clear_registry()
+        _reset_registry()
 
         @jarvis.app()
         class MyCalculator:
@@ -78,7 +78,7 @@ class TestMultiRouteRegistration:
     """Tests for registering multiple endpoint routes."""
 
     def test_registers_multiple_routes(self):
-        clear_registry()
+        _reset_registry()
 
         @jarvis.app()
         class Calculator:
@@ -98,7 +98,7 @@ class TestMultiRouteRegistration:
         assert "/subtract" in paths
 
     def test_custom_paths_registered(self):
-        clear_registry()
+        _reset_registry()
 
         @jarvis.app()
         class Calculator:
@@ -123,7 +123,7 @@ class TestEndpointRoutes:
     """Tests for endpoint route functionality."""
 
     def test_post_to_add_endpoint(self):
-        clear_registry()
+        _reset_registry()
 
         @jarvis.app()
         class Calculator:
@@ -138,7 +138,7 @@ class TestEndpointRoutes:
             assert response.json() == {"result": 8}
 
     def test_post_to_subtract_endpoint(self):
-        clear_registry()
+        _reset_registry()
 
         @jarvis.app()
         class Calculator:
@@ -153,7 +153,7 @@ class TestEndpointRoutes:
             assert response.json() == {"result": 6}
 
     def test_multiple_endpoints_work_together(self):
-        clear_registry()
+        _reset_registry()
 
         @jarvis.app()
         class Calculator:
@@ -176,7 +176,7 @@ class TestEndpointRoutes:
             assert client.post("/multiply", json={"a": 4, "b": 3}).json() == {"result": 12}
 
     def test_invalid_input_returns_422(self):
-        clear_registry()
+        _reset_registry()
 
         @jarvis.app()
         class Calculator:
@@ -194,7 +194,7 @@ class TestSharedState:
     """Tests for shared state across endpoints."""
 
     def test_shared_instance_across_endpoints(self):
-        clear_registry()
+        _reset_registry()
 
         @jarvis.app()
         class Counter:
@@ -221,7 +221,7 @@ class TestSharedState:
             assert response.json() == {"result": 8}
 
     def test_setup_initializes_shared_state(self):
-        clear_registry()
+        _reset_registry()
 
         @jarvis.app()
         class Calculator:
@@ -242,7 +242,7 @@ class TestSetupMethod:
     """Tests for the setup() method lifecycle."""
 
     def test_setup_is_called_on_startup(self):
-        clear_registry()
+        _reset_registry()
 
         @jarvis.app()
         class MyApp:
@@ -260,7 +260,7 @@ class TestSetupMethod:
             assert response.status_code == 200
 
     def test_app_without_setup_works(self):
-        clear_registry()
+        _reset_registry()
 
         @jarvis.app()
         class MyApp:
@@ -275,7 +275,7 @@ class TestSetupMethod:
             assert response.json() == {"result": 10}
 
     def test_setup_failure_prevents_startup(self):
-        clear_registry()
+        _reset_registry()
 
         @jarvis.app()
         class MyApp:
@@ -297,7 +297,7 @@ class TestErrorHandling:
     """Tests for error handling in endpoints."""
 
     def test_exception_in_endpoint_returns_500(self):
-        clear_registry()
+        _reset_registry()
 
         @jarvis.app()
         class MyApp:
@@ -316,7 +316,7 @@ class TestOpenAPIDocs:
     """Tests for OpenAPI documentation."""
 
     def test_openapi_docs_available(self):
-        clear_registry()
+        _reset_registry()
 
         @jarvis.app(name="Calculator")
         class Calculator:
@@ -331,7 +331,7 @@ class TestOpenAPIDocs:
         assert response.status_code == 200
 
     def test_openapi_json_has_all_endpoints(self):
-        clear_registry()
+        _reset_registry()
 
         @jarvis.app(name="Calculator")
         class Calculator:


### PR DESCRIPTION
Fixes #3

Simplifies the Jarvis SDK from supporting multiple app classes to a single-app design, which better matches ML/DL inference use cases.

## Changes
- Replaced multi-app registry with single-app variable
- Added `MultipleAppsError` exception for clear error messages
- Updated CLI to work with single-app model
- Updated all tests to use new API

## Rationale
For ML inference workloads:
1. **GPU memory constraints** - Models like SD/Flux consume significant VRAM
2. **Scaling** - Different models need independent scaling
3. **Industry alignment** - Matches patterns from Replicate, fal.ai, Modal
4. **Simplicity** - Reduces cognitive overhead

Generated with [Claude Code](https://claude.ai/code)