### PR TITLE
Simplify cache configuration: Single JLSERVE_CACHE_DIR for weights and packages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,3 +93,10 @@ def get_jlserve_cache_dir() -> Path:
 - Tests remain focused and maintainable
 - Faster test execution
 - Clearer signal when tests fail (business logic issue, not stdlib)
+
+## Code Quality Best Practices
+
+### DRY Principle (Don't Repeat Yourself)
+
+Always look for code duplication and refactor to shared helpers when you see the same logic repeated:
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,3 +55,41 @@ class MyModel:
 - All endpoint inputs/outputs must be Pydantic BaseModel subclasses
 - Endpoint methods require type hints for both input parameter and return type
 - The app instance is created once and reused across all requests
+
+## Testing Philosophy
+
+JLServe follows a **pragmatic testing approach** that focuses on testing business logic, not standard library wrappers:
+
+### What to Test
+- ✅ **Business logic** - Validation rules, error handling, custom behavior
+- ✅ **Integration points** - How components work together (CLI → config → server)
+- ✅ **Edge cases** - Error conditions, missing inputs, invalid configurations
+- ✅ **Public APIs** - Functions/classes that users interact with
+
+### What NOT to Test
+- ❌ **Simple getters/setters** - Wrappers around `os.getenv()`, `Path()`, etc.
+- ❌ **Standard library behavior** - Testing that `Path.exists()` works
+- ❌ **Trivial forwarding** - Functions that just call another function without logic
+
+### Example
+
+```python
+# DON'T test this (simple wrapper)
+def get_cache_dir_str() -> str:
+    return os.getenv("JLSERVE_CACHE_DIR")
+
+# DO test this (business logic + validation)
+def get_jlserve_cache_dir() -> Path:
+    cache_dir_str = os.getenv("JLSERVE_CACHE_DIR")
+    if not cache_dir_str:
+        raise CacheConfigError("JLSERVE_CACHE_DIR must be set")
+    cache_dir = Path(cache_dir_str)
+    if not cache_dir.exists():
+        raise CacheConfigError(f"Directory does not exist: {cache_dir}")
+    return cache_dir
+```
+
+### Benefits
+- Tests remain focused and maintainable
+- Faster test execution
+- Clearer signal when tests fail (business logic issue, not stdlib)

--- a/README.md
+++ b/README.md
@@ -40,7 +40,12 @@ class Output(BaseModel):
 
 @jlserve.app()
 class Greeter:
+    def download_weights(self):
+        """Download/prepare any resources (required method)."""
+        pass  # No weights needed for this simple example
+
     def setup(self):
+        """Initialize on server startup (required method)."""
         self.prefix = "Hello"
 
     @jlserve.endpoint()
@@ -51,6 +56,9 @@ class Greeter:
 Run the server:
 
 ```bash
+export JLSERVE_CACHE_DIR=/tmp/cache
+mkdir -p $JLSERVE_CACHE_DIR
+jlserve build app.py
 jlserve dev app.py
 ```
 
@@ -100,7 +108,8 @@ Decorator that marks a method as an endpoint within the app class.
 
 | Method            | Required | Description                                                                 |
 |-------------------|----------|-----------------------------------------------------------------------------|
-| `setup(self)`     | No       | Called once when server starts. Use for loading models, initializing resources. |
+| `download_weights(self)` | Yes | Called by `jlserve build`. Download and cache model weights to `JLSERVE_CACHE_DIR`. |
+| `setup(self)`     | Yes      | Called once when server starts. Load models from cache. |
 | `<endpoint_method>(self, input) -> output` | Yes | Endpoint methods decorated with `@jlserve.endpoint()`. Must have type hints for input and output. |
 
 ### Input/Output Requirements
@@ -111,9 +120,24 @@ Decorator that marks a method as an endpoint within the app class.
 
 ## CLI Reference
 
+### `jlserve build <file>`
+
+Builds the app by installing dependencies and downloading model weights to cache. Run this once before starting the server, or when dependencies/models change.
+
+```bash
+export JLSERVE_CACHE_DIR=/path/to/cache
+jlserve build app.py
+```
+
+This command:
+1. Validates that `JLSERVE_CACHE_DIR` is set
+2. Installs Python dependencies (cached to `JLSERVE_CACHE_DIR`)
+3. Calls `download_weights()` to cache model files
+4. Creates a build marker for `dev` command
+
 ### `jlserve dev <file>`
 
-Runs the app locally for development.
+Runs the app locally for development. Requires `jlserve build` to be run first.
 
 | Option   | Default | Description       |
 |----------|---------|-------------------|
@@ -124,6 +148,12 @@ Example:
 ```bash
 jlserve dev app.py --port 3000
 ```
+
+## Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `JLSERVE_CACHE_DIR` | Yes | Directory for caching model weights and Python packages. Must be set before running `build` or `dev`. In containerized environments (like JarvisLabs), point this to a persistent volume to avoid re-downloading on restarts. |
 
 ## Auto-Generated Features
 
@@ -144,9 +174,63 @@ jlserve dev app.py --port 3000
 | Exception in endpoint method | 500 response with error message                       |
 | Exception in `setup()`       | Server fails to start with error message              |
 
+## Weight Caching for Fast Startup
+
+JLServe separates weight downloading from server startup for faster container restarts.
+
+### The Pattern
+
+```python
+@jlserve.app()
+class MyModel:
+    def download_weights(self):
+        """Download model weights to cache (called by 'jlserve build')"""
+        # Download once, save to JLSERVE_CACHE_DIR
+        model = download_model("my-model", cache_dir=os.getenv("JLSERVE_CACHE_DIR"))
+
+    def setup(self):
+        """Load model from cache (called on server startup)"""
+        # Load from cache, don't re-download
+        self.model = load_model("my-model", cache_dir=os.getenv("JLSERVE_CACHE_DIR"))
+
+    @jlserve.endpoint()
+    def predict(self, input: Input) -> Output:
+        return self.model.run(input)
+```
+
+### Workflow
+
+1. **Set cache directory** (point to persistent storage):
+   ```bash
+   export JLSERVE_CACHE_DIR=/workspace/cache
+   ```
+
+2. **Build once** (downloads weights and dependencies):
+   ```bash
+   jlserve build app.py
+   ```
+
+3. **Run server** (loads from cache, fast startup):
+   ```bash
+   jlserve dev app.py
+   ```
+
+On container restarts, skip step 2 - weights are already cached!
+
+### Why Two Commands?
+
+- **`build`**: Downloads weights to cache (run once, or when model changes)
+- **`dev`**: Loads weights from cache (fast startup, run on every restart)
+
+This pattern is essential for containerized deployments where you want to:
+- Avoid re-downloading large model files on every restart
+- Persist dependencies and weights across container lifecycles
+- Optimize startup time in production environments
+
 ## Example: ML Inference
 
 ```python
+import os
 import jlserve
 from pydantic import BaseModel
 
@@ -162,8 +246,17 @@ class SentimentOutput(BaseModel):
 
 @jlserve.app(requirements=["transformers"])
 class SentimentAnalyzer:
-    def setup(self):
+    def download_weights(self):
+        """Download model to cache during build."""
         from transformers import pipeline
+        # Downloads model files to HuggingFace cache
+        # (transformers respects HF_HOME which can be set to JLSERVE_CACHE_DIR)
+        pipeline("sentiment-analysis")
+
+    def setup(self):
+        """Load model from cache on server startup."""
+        from transformers import pipeline
+        # Loads from cache, no download needed
         self.pipe = pipeline("sentiment-analysis")
 
     @jlserve.endpoint()
@@ -173,6 +266,14 @@ class SentimentAnalyzer:
             label=result["label"],
             score=result["score"]
         )
+```
+
+Run it:
+
+```bash
+export JLSERVE_CACHE_DIR=/workspace/cache
+jlserve build app.py  # Downloads transformers model once
+jlserve dev app.py    # Fast startup, loads from cache
 ```
 
 ## Development

--- a/jlserve/cli.py
+++ b/jlserve/cli.py
@@ -1,16 +1,16 @@
 """CLI implementation for JLServe."""
 
-import importlib.util
-import subprocess
-import sys
 from pathlib import Path
 
 import typer
 import uvicorn
 
-from jlserve.decorator import _reset_registry, get_endpoint_methods, get_registered_app
-from jlserve.requirements import extract_requirements_from_file
+from jlserve.cli_utils import install_requirements, load_app_class, validate_python_file
+from jlserve.config import get_jlserve_cache_dir
+from jlserve.decorator import get_endpoint_methods
+from jlserve.exceptions import CacheConfigError
 from jlserve.server import create_app
+from jlserve.validator import validate_app
 
 app = typer.Typer(
     help="JLServe - A simple framework for creating ML endpoints",
@@ -31,72 +31,17 @@ def dev(
     port: int = typer.Option(8000, "--port", "-p", help="Port to serve on"),
 ) -> None:
     """Run an app locally for development."""
-    if not file.exists():
-        typer.echo(f"Error: File not found: {file}", err=True)
-        raise typer.Exit(1)
+    # Validate file exists and is a Python file
+    validate_python_file(file)
 
-    if not file.suffix == ".py":
-        typer.echo(f"Error: File must be a Python file: {file}", err=True)
-        raise typer.Exit(1)
+    # Extract and install any requirements specified in @jlserve.app(requirements=[...])
+    # This happens before import to avoid chicken-and-egg problems
+    install_requirements(file)
 
-    # Step 1: Extract requirements via AST (before importing to avoid import errors)
-    try:
-        requirements = extract_requirements_from_file(str(file))
-    except SyntaxError as e:
-        typer.echo(f"Error: Invalid Python syntax in {file}: {e}", err=True)
-        raise typer.Exit(1)
-    except Exception as e:
-        typer.echo(f"Error: Failed to extract requirements from {file}: {e}", err=True)
-        raise typer.Exit(1)
+    # Import the file and get the @jlserve.app() decorated class
+    app_cls = load_app_class(file)
 
-    # Step 2: Install requirements with uv (shows output, fast if already satisfied)
-    if requirements:
-        typer.echo(f"Installing requirements: {', '.join(requirements)}")
-        try:
-            subprocess.run(
-                ["uv", "pip", "install", *requirements],
-                check=True,
-            )
-        except subprocess.CalledProcessError as e:
-            typer.echo(f"Error: Failed to install requirements: {e}", err=True)
-            raise typer.Exit(1)
-        except FileNotFoundError:
-            typer.echo(
-                "Error: 'uv' command not found. Please install uv: https://github.com/astral-sh/uv",
-                err=True,
-            )
-            raise typer.Exit(1)
-
-    # Clear any previously registered app
-    _reset_registry()
-
-    # Load the user's Python file
-    spec = importlib.util.spec_from_file_location("user_module", file)
-    if spec is None or spec.loader is None:
-        typer.echo(f"Error: Could not load file: {file}", err=True)
-        raise typer.Exit(1)
-
-    module = importlib.util.module_from_spec(spec)
-    sys.modules["user_module"] = module
-    try:
-        spec.loader.exec_module(module)
-    except Exception as e:
-        # Check if it's a MultipleAppsError
-        if "MultipleAppsError" in type(e).__name__ or "multiple" in str(e).lower():
-            typer.echo(f"Error: {e}", err=True)
-            raise typer.Exit(1)
-        # Re-raise other exceptions
-        raise
-
-    # Get the registered app
-    app_cls = get_registered_app()
-    if app_cls is None:
-        typer.echo(
-            "Error: No app found. Did you decorate a class with @jlserve.app()?",
-            err=True,
-        )
-        raise typer.Exit(1)
-
+    # Get the app name for display purposes
     app_name = getattr(app_cls, "_jlserve_app_name", "app")
 
     # Get endpoint methods for display
@@ -121,6 +66,57 @@ def dev(
 
     # Start Uvicorn server
     uvicorn.run(fastapi_app, host="0.0.0.0", port=port, log_level="info")
+
+
+@app.command("build")
+def build(
+    file: Path = typer.Argument(..., help="Path to the Python file containing the app"),
+) -> None:
+    """Build app by installing dependencies and downloading weights to cache.
+
+    This command is used in deployment pipelines to:
+    1. Install all required dependencies
+    2. Pre-download model weights to the cache directory
+    3. Validate the app structure before deployment
+    """
+    # Validate file exists and is a Python file
+    validate_python_file(file)
+
+    # Check that JLSERVE_CACHE_DIR is configured (required for build)
+    try:
+        cache_dir = get_jlserve_cache_dir()
+        typer.echo(f"✓ Cache directory: {cache_dir}")
+    except CacheConfigError as e:
+        typer.echo(f"Error: {e}", err=True)
+        raise typer.Exit(1)
+
+    # Extract and install requirements via AST parsing (before import)
+    install_requirements(file)
+
+    # Import the file and get the @jlserve.app() decorated class
+    app_cls = load_app_class(file)
+    app_name = getattr(app_cls, "_jlserve_app_name", "app")
+
+    # Validate app has required lifecycle methods (setup, download_weights, endpoints)
+    try:
+        validate_app(app_cls)
+    except Exception as e:
+        typer.echo(f"Error: App validation failed: {e}", err=True)
+        raise typer.Exit(1)
+
+    # Create app instance and trigger weight download
+    typer.echo(f"✓ Loading app: {app_name}")
+    app_instance = app_cls()
+
+    # Call download_weights() to pre-fetch model files to cache
+    typer.echo("✓ Downloading weights...")
+    try:
+        app_instance.download_weights()
+    except Exception as e:
+        typer.echo(f"Error: download_weights() failed: {e}", err=True)
+        raise typer.Exit(1)
+
+    typer.echo("✓ Build complete!")
 
 
 if __name__ == "__main__":

--- a/jlserve/cli_test.py
+++ b/jlserve/cli_test.py
@@ -47,24 +47,38 @@ class TestDevCommand:
         finally:
             Path(temp_path).unlink()
 
-    def test_dev_no_app_found(self):
+    @patch("jlserve.cli.get_jlserve_cache_dir")
+    def test_dev_no_app_found(self, mock_cache_dir):
         """Test error message when no @jlserve.app() decorated class is found."""
-        with tempfile.NamedTemporaryFile(suffix=".py", delete=False) as f:
-            f.write(b"# empty python file\nx = 1\n")
-            temp_path = f.name
+        # Setup mock cache with marker file
+        with tempfile.TemporaryDirectory() as cache_dir_str:
+            cache_dir = Path(cache_dir_str)
+            mock_cache_dir.return_value = cache_dir
+            (cache_dir / ".jlserve-build-complete").touch()
 
-        try:
-            result = runner.invoke(app, ["dev", temp_path])
-            assert result.exit_code == 1
-            assert "No app found" in result.output
-            assert "@jlserve.app()" in result.output
-        finally:
-            Path(temp_path).unlink()
+            with tempfile.NamedTemporaryFile(suffix=".py", delete=False) as f:
+                f.write(b"# empty python file\nx = 1\n")
+                temp_path = f.name
 
-    def test_dev_app_with_no_endpoints(self):
+            try:
+                result = runner.invoke(app, ["dev", temp_path])
+                assert result.exit_code == 1
+                assert "No app found" in result.output
+                assert "@jlserve.app()" in result.output
+            finally:
+                Path(temp_path).unlink()
+
+    @patch("jlserve.cli.get_jlserve_cache_dir")
+    def test_dev_app_with_no_endpoints(self, mock_cache_dir):
         """Test error message when app has no @jlserve.endpoint() methods."""
-        with tempfile.NamedTemporaryFile(suffix=".py", delete=False) as f:
-            code = b"""
+        # Setup mock cache with marker file
+        with tempfile.TemporaryDirectory() as cache_dir_str:
+            cache_dir = Path(cache_dir_str)
+            mock_cache_dir.return_value = cache_dir
+            (cache_dir / ".jlserve-build-complete").touch()
+
+            with tempfile.NamedTemporaryFile(suffix=".py", delete=False) as f:
+                code = b"""
 import jlserve
 
 @jlserve.app()
@@ -77,16 +91,16 @@ class EmptyApp:
 
     pass
 """
-            f.write(code)
-            temp_path = f.name
+                f.write(code)
+                temp_path = f.name
 
-        try:
-            result = runner.invoke(app, ["dev", temp_path])
-            assert result.exit_code == 1
-            assert "no endpoints" in result.output.lower()
-            assert "@jlserve.endpoint()" in result.output
-        finally:
-            Path(temp_path).unlink()
+            try:
+                result = runner.invoke(app, ["dev", temp_path])
+                assert result.exit_code == 1
+                assert "no endpoints" in result.output.lower()
+                assert "@jlserve.endpoint()" in result.output
+            finally:
+                Path(temp_path).unlink()
 
     def test_dev_port_option_default(self):
         result = runner.invoke(app, ["dev", "--help"])
@@ -163,10 +177,17 @@ class TestDevCommandRequirements:
 
     @patch("jlserve.cli_utils.subprocess.run")
     @patch("jlserve.cli.uvicorn.run")
-    def test_dev_installs_requirements(self, mock_uvicorn, mock_subprocess):
+    @patch("jlserve.cli.get_jlserve_cache_dir")
+    def test_dev_installs_requirements(self, mock_cache_dir, mock_uvicorn, mock_subprocess):
         """Test that dev command installs requirements before starting server."""
-        with tempfile.NamedTemporaryFile(suffix=".py", delete=False, mode="w") as f:
-            f.write("""
+        # Setup mock cache with marker file
+        with tempfile.TemporaryDirectory() as cache_dir_str:
+            cache_dir = Path(cache_dir_str)
+            mock_cache_dir.return_value = cache_dir
+            (cache_dir / ".jlserve-build-complete").touch()
+
+            with tempfile.NamedTemporaryFile(suffix=".py", delete=False, mode="w") as f:
+                f.write("""
 import jlserve
 from pydantic import BaseModel
 
@@ -188,31 +209,38 @@ class MyModel:
     def predict(self, input: Input) -> Output:
         return Output(result=input.value * 2)
 """)
-            temp_path = f.name
+                temp_path = f.name
 
-        try:
-            result = runner.invoke(app, ["dev", temp_path])
+            try:
+                result = runner.invoke(app, ["dev", temp_path])
 
-            # Verify subprocess.run was called with correct args
-            mock_subprocess.assert_called_once()
-            call_args = mock_subprocess.call_args[0][0]
-            assert call_args[0] == "uv"
-            assert call_args[1] == "pip"
-            assert call_args[2] == "install"
-            assert "torch" in call_args
-            assert "numpy>=1.24" in call_args
+                # Verify subprocess.run was called with correct args
+                mock_subprocess.assert_called_once()
+                call_args = mock_subprocess.call_args[0][0]
+                assert call_args[0] == "uv"
+                assert call_args[1] == "pip"
+                assert call_args[2] == "install"
+                assert "torch" in call_args
+                assert "numpy>=1.24" in call_args
 
-            # Verify uvicorn was started (server logic)
-            assert mock_uvicorn.called
-        finally:
-            Path(temp_path).unlink()
+                # Verify uvicorn was started (server logic)
+                assert mock_uvicorn.called
+            finally:
+                Path(temp_path).unlink()
 
+    @patch("jlserve.cli.get_jlserve_cache_dir")
     @patch("jlserve.cli_utils.subprocess.run")
     @patch("jlserve.cli.uvicorn.run")
-    def test_dev_no_requirements_skips_install(self, mock_uvicorn, mock_subprocess):
+    def test_dev_no_requirements_skips_install(self, mock_uvicorn, mock_subprocess, mock_cache_dir):
         """Test that dev command skips install when no requirements specified."""
-        with tempfile.NamedTemporaryFile(suffix=".py", delete=False, mode="w") as f:
-            f.write("""
+        # Setup mock cache with marker file
+        with tempfile.TemporaryDirectory() as cache_dir_str:
+            cache_dir = Path(cache_dir_str)
+            mock_cache_dir.return_value = cache_dir
+            (cache_dir / ".jlserve-build-complete").touch()
+
+            with tempfile.NamedTemporaryFile(suffix=".py", delete=False, mode="w") as f:
+                f.write("""
 import jlserve
 from pydantic import BaseModel
 
@@ -234,25 +262,32 @@ class MyModel:
     def predict(self, input: Input) -> Output:
         return Output(result=input.value * 2)
 """)
-            temp_path = f.name
+                temp_path = f.name
 
-        try:
-            result = runner.invoke(app, ["dev", temp_path])
+            try:
+                result = runner.invoke(app, ["dev", temp_path])
 
-            # Verify subprocess.run was NOT called
-            mock_subprocess.assert_not_called()
+                # Verify subprocess.run was NOT called
+                mock_subprocess.assert_not_called()
 
-            # Verify uvicorn was still started
-            assert mock_uvicorn.called
-        finally:
-            Path(temp_path).unlink()
+                # Verify uvicorn was still started
+                assert mock_uvicorn.called
+            finally:
+                Path(temp_path).unlink()
 
+    @patch("jlserve.cli.get_jlserve_cache_dir")
     @patch("jlserve.cli_utils.subprocess.run")
     @patch("jlserve.cli.uvicorn.run")
-    def test_dev_empty_requirements_skips_install(self, mock_uvicorn, mock_subprocess):
+    def test_dev_empty_requirements_skips_install(self, mock_uvicorn, mock_subprocess, mock_cache_dir):
         """Test that dev command skips install when requirements list is empty."""
-        with tempfile.NamedTemporaryFile(suffix=".py", delete=False, mode="w") as f:
-            f.write("""
+        # Setup mock cache with marker file
+        with tempfile.TemporaryDirectory() as cache_dir_str:
+            cache_dir = Path(cache_dir_str)
+            mock_cache_dir.return_value = cache_dir
+            (cache_dir / ".jlserve-build-complete").touch()
+
+            with tempfile.NamedTemporaryFile(suffix=".py", delete=False, mode="w") as f:
+                f.write("""
 import jlserve
 from pydantic import BaseModel
 
@@ -274,46 +309,60 @@ class MyModel:
     def predict(self, input: Input) -> Output:
         return Output(result=input.value * 2)
 """)
-            temp_path = f.name
+                temp_path = f.name
 
-        try:
-            result = runner.invoke(app, ["dev", temp_path])
+            try:
+                result = runner.invoke(app, ["dev", temp_path])
 
-            # Verify subprocess.run was NOT called
-            mock_subprocess.assert_not_called()
+                # Verify subprocess.run was NOT called
+                mock_subprocess.assert_not_called()
 
-            # Verify uvicorn was still started
-            assert mock_uvicorn.called
-        finally:
-            Path(temp_path).unlink()
+                # Verify uvicorn was still started
+                assert mock_uvicorn.called
+            finally:
+                Path(temp_path).unlink()
 
+    @patch("jlserve.cli.get_jlserve_cache_dir")
     @patch("jlserve.cli.uvicorn.run")
-    def test_dev_handles_syntax_error_in_file(self, mock_uvicorn):
+    def test_dev_handles_syntax_error_in_file(self, mock_uvicorn, mock_cache_dir):
         """Test that dev command handles syntax errors gracefully."""
-        with tempfile.NamedTemporaryFile(suffix=".py", delete=False, mode="w") as f:
-            f.write("this is not valid python syntax }{[")
-            temp_path = f.name
+        # Setup mock cache with marker file
+        with tempfile.TemporaryDirectory() as cache_dir_str:
+            cache_dir = Path(cache_dir_str)
+            mock_cache_dir.return_value = cache_dir
+            (cache_dir / ".jlserve-build-complete").touch()
 
-        try:
-            result = runner.invoke(app, ["dev", temp_path])
-            assert result.exit_code == 1
-            assert "Invalid Python syntax" in result.output
+            with tempfile.NamedTemporaryFile(suffix=".py", delete=False, mode="w") as f:
+                f.write("this is not valid python syntax }{[")
+                temp_path = f.name
 
-            # Verify uvicorn was NOT started
-            mock_uvicorn.assert_not_called()
-        finally:
-            Path(temp_path).unlink()
+            try:
+                result = runner.invoke(app, ["dev", temp_path])
+                assert result.exit_code == 1
+                assert "Invalid Python syntax" in result.output
 
+                # Verify uvicorn was NOT started
+                mock_uvicorn.assert_not_called()
+            finally:
+                Path(temp_path).unlink()
+
+    @patch("jlserve.cli.get_jlserve_cache_dir")
     @patch("jlserve.cli_utils.subprocess.run")
     @patch("jlserve.cli.uvicorn.run")
-    def test_dev_handles_subprocess_error(self, mock_uvicorn, mock_subprocess):
+    def test_dev_handles_subprocess_error(self, mock_uvicorn, mock_subprocess, mock_cache_dir):
         """Test that dev command handles pip install failures."""
         from subprocess import CalledProcessError
 
-        mock_subprocess.side_effect = CalledProcessError(1, "uv pip install")
+        # Setup mock cache with marker file
+        with tempfile.TemporaryDirectory() as cache_dir_str:
+            cache_dir = Path(cache_dir_str)
+            mock_cache_dir.return_value = cache_dir
+            (cache_dir / ".jlserve-build-complete").touch()
 
-        with tempfile.NamedTemporaryFile(suffix=".py", delete=False, mode="w") as f:
-            f.write("""
+            mock_subprocess.side_effect = CalledProcessError(1, "uv pip install")
+
+            with tempfile.NamedTemporaryFile(suffix=".py", delete=False, mode="w") as f:
+                f.write("""
 import jlserve
 from pydantic import BaseModel
 
@@ -335,26 +384,33 @@ class MyModel:
     def predict(self, input: Input) -> Output:
         return Output(result=input.value * 2)
 """)
-            temp_path = f.name
+                temp_path = f.name
 
-        try:
-            result = runner.invoke(app, ["dev", temp_path])
-            assert result.exit_code == 1
-            assert "Failed to install requirements" in result.output
+            try:
+                result = runner.invoke(app, ["dev", temp_path])
+                assert result.exit_code == 1
+                assert "Failed to install requirements" in result.output
 
-            # Verify uvicorn was NOT started
-            mock_uvicorn.assert_not_called()
-        finally:
-            Path(temp_path).unlink()
+                # Verify uvicorn was NOT started
+                mock_uvicorn.assert_not_called()
+            finally:
+                Path(temp_path).unlink()
 
+    @patch("jlserve.cli.get_jlserve_cache_dir")
     @patch("jlserve.cli_utils.subprocess.run")
     @patch("jlserve.cli.uvicorn.run")
-    def test_dev_handles_uv_not_found(self, mock_uvicorn, mock_subprocess):
+    def test_dev_handles_uv_not_found(self, mock_uvicorn, mock_subprocess, mock_cache_dir):
         """Test that dev command handles missing uv command."""
-        mock_subprocess.side_effect = FileNotFoundError()
+        # Setup mock cache with marker file
+        with tempfile.TemporaryDirectory() as cache_dir_str:
+            cache_dir = Path(cache_dir_str)
+            mock_cache_dir.return_value = cache_dir
+            (cache_dir / ".jlserve-build-complete").touch()
 
-        with tempfile.NamedTemporaryFile(suffix=".py", delete=False, mode="w") as f:
-            f.write("""
+            mock_subprocess.side_effect = FileNotFoundError()
+
+            with tempfile.NamedTemporaryFile(suffix=".py", delete=False, mode="w") as f:
+                f.write("""
 import jlserve
 from pydantic import BaseModel
 
@@ -376,25 +432,32 @@ class MyModel:
     def predict(self, input: Input) -> Output:
         return Output(result=input.value * 2)
 """)
-            temp_path = f.name
+                temp_path = f.name
 
-        try:
-            result = runner.invoke(app, ["dev", temp_path])
-            assert result.exit_code == 1
-            assert "'uv' command not found" in result.output
+            try:
+                result = runner.invoke(app, ["dev", temp_path])
+                assert result.exit_code == 1
+                assert "'uv' command not found" in result.output
 
-            # Verify uvicorn was NOT started
-            mock_uvicorn.assert_not_called()
-        finally:
-            Path(temp_path).unlink()
+                # Verify uvicorn was NOT started
+                mock_uvicorn.assert_not_called()
+            finally:
+                Path(temp_path).unlink()
 
+    @patch("jlserve.cli.get_jlserve_cache_dir")
     @patch("jlserve.cli_utils.subprocess.run")
     @patch("jlserve.cli.uvicorn.run")
-    def test_dev_extracts_requirements_before_import(self, mock_uvicorn, mock_subprocess):
+    def test_dev_extracts_requirements_before_import(self, mock_uvicorn, mock_subprocess, mock_cache_dir):
         """Test that requirements are extracted via AST before importing (chicken-and-egg fix)."""
-        # This file has imports that would fail if not installed
-        with tempfile.NamedTemporaryFile(suffix=".py", delete=False, mode="w") as f:
-            f.write("""
+        # Setup mock cache with marker file
+        with tempfile.TemporaryDirectory() as cache_dir_str:
+            cache_dir = Path(cache_dir_str)
+            mock_cache_dir.return_value = cache_dir
+            (cache_dir / ".jlserve-build-complete").touch()
+
+            # This file has imports that would fail if not installed
+            with tempfile.NamedTemporaryFile(suffix=".py", delete=False, mode="w") as f:
+                f.write("""
 # These imports would fail if packages aren't installed
 # import torch
 # import transformers
@@ -420,21 +483,21 @@ class MyModel:
     def predict(self, input: Input) -> Output:
         return Output(result=input.value * 2)
 """)
-            temp_path = f.name
+                temp_path = f.name
 
-        try:
-            result = runner.invoke(app, ["dev", temp_path])
+            try:
+                result = runner.invoke(app, ["dev", temp_path])
 
-            # Verify requirements were extracted and install attempted
-            mock_subprocess.assert_called_once()
-            call_args = mock_subprocess.call_args[0][0]
-            assert "torch" in call_args
-            assert "transformers" in call_args
+                # Verify requirements were extracted and install attempted
+                mock_subprocess.assert_called_once()
+                call_args = mock_subprocess.call_args[0][0]
+                assert "torch" in call_args
+                assert "transformers" in call_args
 
-            # The key test: extraction happened via AST, not via import
-            # If we had imported the file first, the commented imports would fail
-        finally:
-            Path(temp_path).unlink()
+                # The key test: extraction happened via AST, not via import
+                # If we had imported the file first, the commented imports would fail
+            finally:
+                Path(temp_path).unlink()
 
 
 class TestBuildCommand:
@@ -444,12 +507,14 @@ class TestBuildCommand:
     @patch("jlserve.cli.get_jlserve_cache_dir")
     def test_build_success(self, mock_cache_dir, mock_subprocess):
         """Test that build command successfully downloads weights."""
-        # Setup mock cache directory
-        mock_cache_dir.return_value = Path("/tmp/cache")
+        # Create a real temp directory for cache
+        with tempfile.TemporaryDirectory() as cache_dir_str:
+            cache_dir = Path(cache_dir_str)
+            mock_cache_dir.return_value = cache_dir
 
-        # Create test app file
-        with tempfile.NamedTemporaryFile(suffix=".py", delete=False, mode="w") as f:
-            f.write("""
+            # Create test app file
+            with tempfile.NamedTemporaryFile(suffix=".py", delete=False, mode="w") as f:
+                f.write("""
 import jlserve
 from pydantic import BaseModel
 
@@ -472,19 +537,19 @@ class MyModel:
     def predict(self, input: Input) -> Output:
         return Output(result=input.value * 2)
 """)
-            temp_path = f.name
+                temp_path = f.name
 
-        try:
-            result = runner.invoke(app, ["build", temp_path])
+            try:
+                result = runner.invoke(app, ["build", temp_path])
 
-            # Verify success
-            assert result.exit_code == 0
-            assert "✓ Cache directory: /tmp/cache" in result.output
-            assert "✓ Loading app: MyModel" in result.output
-            assert "✓ Downloading weights..." in result.output
-            assert "✓ Build complete!" in result.output
-        finally:
-            Path(temp_path).unlink()
+                # Verify success
+                assert result.exit_code == 0
+                assert f"✓ Cache directory: {cache_dir}" in result.output
+                assert "✓ Loading app: MyModel" in result.output
+                assert "✓ Downloading weights..." in result.output
+                assert "✓ Build complete!" in result.output
+            finally:
+                Path(temp_path).unlink()
 
     def test_build_file_not_found(self):
         """Test that build command fails when file doesn't exist."""
@@ -550,12 +615,14 @@ class MyModel:
     @patch("jlserve.cli.get_jlserve_cache_dir")
     def test_build_download_weights_fails(self, mock_cache_dir, mock_subprocess):
         """Test that build command handles download_weights() failures."""
-        # Setup mock cache directory
-        mock_cache_dir.return_value = Path("/tmp/cache")
+        # Create a real temp directory for cache
+        with tempfile.TemporaryDirectory() as cache_dir_str:
+            cache_dir = Path(cache_dir_str)
+            mock_cache_dir.return_value = cache_dir
 
-        # Create test app file where download_weights raises error
-        with tempfile.NamedTemporaryFile(suffix=".py", delete=False, mode="w") as f:
-            f.write("""
+            # Create test app file where download_weights raises error
+            with tempfile.NamedTemporaryFile(suffix=".py", delete=False, mode="w") as f:
+                f.write("""
 import jlserve
 from pydantic import BaseModel
 
@@ -577,26 +644,28 @@ class MyModel:
     def predict(self, input: Input) -> Output:
         return Output(result=input.value * 2)
 """)
-            temp_path = f.name
+                temp_path = f.name
 
-        try:
-            result = runner.invoke(app, ["build", temp_path])
-            assert result.exit_code == 1
-            assert "Error: download_weights() failed" in result.output
-            assert "Network error downloading model" in result.output
-        finally:
-            Path(temp_path).unlink()
+            try:
+                result = runner.invoke(app, ["build", temp_path])
+                assert result.exit_code == 1
+                assert "Error: download_weights() failed" in result.output
+                assert "Network error downloading model" in result.output
+            finally:
+                Path(temp_path).unlink()
 
     @patch("jlserve.cli_utils.subprocess.run")
     @patch("jlserve.cli.get_jlserve_cache_dir")
     def test_build_installs_requirements(self, mock_cache_dir, mock_subprocess):
         """Test that build command installs requirements before loading app."""
-        # Setup mock cache directory
-        mock_cache_dir.return_value = Path("/tmp/cache")
+        # Create a real temp directory for cache
+        with tempfile.TemporaryDirectory() as cache_dir_str:
+            cache_dir = Path(cache_dir_str)
+            mock_cache_dir.return_value = cache_dir
 
-        # Create test app file with requirements
-        with tempfile.NamedTemporaryFile(suffix=".py", delete=False, mode="w") as f:
-            f.write("""
+            # Create test app file with requirements
+            with tempfile.NamedTemporaryFile(suffix=".py", delete=False, mode="w") as f:
+                f.write("""
 import jlserve
 from pydantic import BaseModel
 
@@ -618,33 +687,35 @@ class MyModel:
     def predict(self, input: Input) -> Output:
         return Output(result=input.value * 2)
 """)
-            temp_path = f.name
+                temp_path = f.name
 
-        try:
-            result = runner.invoke(app, ["build", temp_path])
-            assert result.exit_code == 0
+            try:
+                result = runner.invoke(app, ["build", temp_path])
+                assert result.exit_code == 0
 
-            # Verify subprocess.run was called with correct args
-            mock_subprocess.assert_called_once()
-            call_args = mock_subprocess.call_args[0][0]
-            assert call_args[0] == "uv"
-            assert call_args[1] == "pip"
-            assert call_args[2] == "install"
-            assert "torch" in call_args
-            assert "numpy>=1.24" in call_args
-        finally:
-            Path(temp_path).unlink()
+                # Verify subprocess.run was called with correct args
+                mock_subprocess.assert_called_once()
+                call_args = mock_subprocess.call_args[0][0]
+                assert call_args[0] == "uv"
+                assert call_args[1] == "pip"
+                assert call_args[2] == "install"
+                assert "torch" in call_args
+                assert "numpy>=1.24" in call_args
+            finally:
+                Path(temp_path).unlink()
 
     @patch("jlserve.cli_utils.subprocess.run")
     @patch("jlserve.cli.get_jlserve_cache_dir")
     def test_build_validates_app_structure(self, mock_cache_dir, mock_subprocess):
         """Test that build command validates app structure."""
-        # Setup mock cache directory
-        mock_cache_dir.return_value = Path("/tmp/cache")
+        # Create a real temp directory for cache
+        with tempfile.TemporaryDirectory() as cache_dir_str:
+            cache_dir = Path(cache_dir_str)
+            mock_cache_dir.return_value = cache_dir
 
-        # Create test app file with missing download_weights
-        with tempfile.NamedTemporaryFile(suffix=".py", delete=False, mode="w") as f:
-            f.write("""
+            # Create test app file with missing download_weights
+            with tempfile.NamedTemporaryFile(suffix=".py", delete=False, mode="w") as f:
+                f.write("""
 import jlserve
 from pydantic import BaseModel
 
@@ -665,12 +736,206 @@ class MyModel:
     def predict(self, input: Input) -> Output:
         return Output(result=input.value * 2)
 """)
+                temp_path = f.name
+
+            try:
+                result = runner.invoke(app, ["build", temp_path])
+                assert result.exit_code == 1
+                assert "Error: App validation failed" in result.output
+                assert "download_weights" in result.output.lower()
+            finally:
+                Path(temp_path).unlink()
+
+    @patch("jlserve.cli_utils.subprocess.run")
+    @patch("jlserve.cli.get_jlserve_cache_dir")
+    def test_build_creates_marker_file(self, mock_cache_dir, mock_subprocess):
+        """Test that build command creates marker file after successful build."""
+        import tempfile
+
+        # Create a real temp directory for cache
+        with tempfile.TemporaryDirectory() as cache_dir_str:
+            cache_dir = Path(cache_dir_str)
+            mock_cache_dir.return_value = cache_dir
+
+            # Create test app file
+            with tempfile.NamedTemporaryFile(suffix=".py", delete=False, mode="w") as f:
+                f.write("""
+import jlserve
+from pydantic import BaseModel
+
+class Input(BaseModel):
+    value: int
+
+class Output(BaseModel):
+    result: int
+
+@jlserve.app()
+class MyModel:
+    def setup(self) -> None:
+        pass
+
+    def download_weights(self) -> None:
+        pass
+
+    @jlserve.endpoint()
+    def predict(self, input: Input) -> Output:
+        return Output(result=input.value * 2)
+""")
+                temp_path = f.name
+
+            try:
+                # Marker should not exist before build
+                marker_file = cache_dir / ".jlserve-build-complete"
+                assert not marker_file.exists()
+
+                # Run build
+                result = runner.invoke(app, ["build", temp_path])
+                assert result.exit_code == 0
+
+                # Marker should exist after build
+                assert marker_file.exists()
+            finally:
+                Path(temp_path).unlink()
+
+class TestDevCommandMarkerValidation:
+    """Tests for dev command marker file validation."""
+
+    @patch("jlserve.cli.get_jlserve_cache_dir")
+    def test_dev_fails_when_cache_dir_not_set(self, mock_cache_dir):
+        """Test that dev command fails when JLSERVE_CACHE_DIR is not set."""
+        from jlserve.exceptions import CacheConfigError
+
+        # Mock cache_dir to raise error
+        mock_cache_dir.side_effect = CacheConfigError("JLSERVE_CACHE_DIR environment variable must be set")
+
+        # Create test app file
+        with tempfile.NamedTemporaryFile(suffix=".py", delete=False, mode="w") as f:
+            f.write("""
+import jlserve
+from pydantic import BaseModel
+
+class Input(BaseModel):
+    value: int
+
+class Output(BaseModel):
+    result: int
+
+@jlserve.app()
+class MyModel:
+    def setup(self) -> None:
+        pass
+
+    def download_weights(self) -> None:
+        pass
+
+    @jlserve.endpoint()
+    def predict(self, input: Input) -> Output:
+        return Output(result=input.value * 2)
+""")
             temp_path = f.name
 
         try:
-            result = runner.invoke(app, ["build", temp_path])
+            result = runner.invoke(app, ["dev", temp_path])
             assert result.exit_code == 1
-            assert "Error: App validation failed" in result.output
-            assert "download_weights" in result.output.lower()
+            assert "JLSERVE_CACHE_DIR environment variable must be set" in result.output
+            assert "jlserve build" in result.output
         finally:
             Path(temp_path).unlink()
+
+    @patch("jlserve.cli.get_jlserve_cache_dir")
+    def test_dev_fails_when_marker_file_missing(self, mock_cache_dir):
+        """Test that dev command fails when marker file doesn't exist."""
+        import tempfile
+
+        # Create a real temp directory for cache (without marker file)
+        with tempfile.TemporaryDirectory() as cache_dir_str:
+            cache_dir = Path(cache_dir_str)
+            mock_cache_dir.return_value = cache_dir
+
+            # Create test app file
+            with tempfile.NamedTemporaryFile(suffix=".py", delete=False, mode="w") as f:
+                f.write("""
+import jlserve
+from pydantic import BaseModel
+
+class Input(BaseModel):
+    value: int
+
+class Output(BaseModel):
+    result: int
+
+@jlserve.app()
+class MyModel:
+    def setup(self) -> None:
+        pass
+
+    def download_weights(self) -> None:
+        pass
+
+    @jlserve.endpoint()
+    def predict(self, input: Input) -> Output:
+        return Output(result=input.value * 2)
+""")
+                temp_path = f.name
+
+            try:
+                # Ensure marker doesn't exist
+                marker_file = cache_dir / ".jlserve-build-complete"
+                assert not marker_file.exists()
+
+                result = runner.invoke(app, ["dev", temp_path])
+                assert result.exit_code == 1
+                assert "Build marker not found" in result.output
+                assert "jlserve build" in result.output
+                assert str(cache_dir) in result.output
+            finally:
+                Path(temp_path).unlink()
+
+    @patch("jlserve.cli_utils.subprocess.run")
+    @patch("jlserve.cli.uvicorn.run")
+    @patch("jlserve.cli.get_jlserve_cache_dir")
+    def test_dev_succeeds_when_marker_file_exists(self, mock_cache_dir, mock_uvicorn, mock_subprocess):
+        """Test that dev command succeeds when marker file exists."""
+        import tempfile
+
+        # Create a real temp directory for cache
+        with tempfile.TemporaryDirectory() as cache_dir_str:
+            cache_dir = Path(cache_dir_str)
+            mock_cache_dir.return_value = cache_dir
+
+            # Create marker file
+            marker_file = cache_dir / ".jlserve-build-complete"
+            marker_file.touch()
+
+            # Create test app file
+            with tempfile.NamedTemporaryFile(suffix=".py", delete=False, mode="w") as f:
+                f.write("""
+import jlserve
+from pydantic import BaseModel
+
+class Input(BaseModel):
+    value: int
+
+class Output(BaseModel):
+    result: int
+
+@jlserve.app()
+class MyModel:
+    def setup(self) -> None:
+        pass
+
+    def download_weights(self) -> None:
+        pass
+
+    @jlserve.endpoint()
+    def predict(self, input: Input) -> Output:
+        return Output(result=input.value * 2)
+""")
+                temp_path = f.name
+
+            try:
+                result = runner.invoke(app, ["dev", temp_path])
+                # Should succeed and start server
+                assert mock_uvicorn.called
+            finally:
+                Path(temp_path).unlink()

--- a/jlserve/cli_test.py
+++ b/jlserve/cli_test.py
@@ -69,6 +69,12 @@ import jlserve
 
 @jlserve.app()
 class EmptyApp:
+    def setup(self) -> None:
+        pass
+
+    def download_weights(self) -> None:
+        pass
+
     pass
 """
             f.write(code)
@@ -116,6 +122,12 @@ class Output(BaseModel):
 
 @jlserve.app()
 class Calculator:
+    def setup(self) -> None:
+        pass
+
+    def download_weights(self) -> None:
+        pass
+
     @jlserve.endpoint()
     def add(self, input: Input) -> Output:
         return Output(result=input.value + 1)
@@ -166,6 +178,12 @@ class Output(BaseModel):
 
 @jlserve.app(requirements=["torch", "numpy>=1.24"])
 class MyModel:
+    def setup(self) -> None:
+        pass
+
+    def download_weights(self) -> None:
+        pass
+
     @jlserve.endpoint()
     def predict(self, input: Input) -> Output:
         return Output(result=input.value * 2)
@@ -206,6 +224,12 @@ class Output(BaseModel):
 
 @jlserve.app()
 class MyModel:
+    def setup(self) -> None:
+        pass
+
+    def download_weights(self) -> None:
+        pass
+
     @jlserve.endpoint()
     def predict(self, input: Input) -> Output:
         return Output(result=input.value * 2)
@@ -240,6 +264,12 @@ class Output(BaseModel):
 
 @jlserve.app(requirements=[])
 class MyModel:
+    def setup(self) -> None:
+        pass
+
+    def download_weights(self) -> None:
+        pass
+
     @jlserve.endpoint()
     def predict(self, input: Input) -> Output:
         return Output(result=input.value * 2)
@@ -295,6 +325,12 @@ class Output(BaseModel):
 
 @jlserve.app(requirements=["nonexistent-package-xyz"])
 class MyModel:
+    def setup(self) -> None:
+        pass
+
+    def download_weights(self) -> None:
+        pass
+
     @jlserve.endpoint()
     def predict(self, input: Input) -> Output:
         return Output(result=input.value * 2)
@@ -330,6 +366,12 @@ class Output(BaseModel):
 
 @jlserve.app(requirements=["torch"])
 class MyModel:
+    def setup(self) -> None:
+        pass
+
+    def download_weights(self) -> None:
+        pass
+
     @jlserve.endpoint()
     def predict(self, input: Input) -> Output:
         return Output(result=input.value * 2)
@@ -368,6 +410,12 @@ class Output(BaseModel):
 
 @jlserve.app(requirements=["torch", "transformers"])
 class MyModel:
+    def setup(self) -> None:
+        pass
+
+    def download_weights(self) -> None:
+        pass
+
     @jlserve.endpoint()
     def predict(self, input: Input) -> Output:
         return Output(result=input.value * 2)

--- a/jlserve/cli_utils.py
+++ b/jlserve/cli_utils.py
@@ -1,0 +1,139 @@
+"""Shared utilities for CLI commands.
+
+This module provides reusable helper functions for the dev and build commands.
+It was extracted from cli.py to follow the DRY (Don't Repeat Yourself) principle,
+centralizing common logic for:
+
+- File validation (ensuring files exist and are Python files)
+- Requirements extraction and installation (using AST parsing + uv)
+- App loading (dynamic import and registry retrieval)
+
+These utilities handle the core workflow that both commands share:
+1. Validate the input file
+2. Extract and install requirements (without importing)
+3. Dynamically load the file and get the @jlserve.app() class
+"""
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+from typing import Type
+
+import typer
+
+from jlserve.decorator import _reset_registry, get_registered_app
+from jlserve.requirements import extract_requirements_from_file
+
+
+def validate_python_file(file: Path) -> None:
+    """Validate that file exists and is a Python file.
+
+    Args:
+        file: Path to validate.
+
+    Raises:
+        typer.Exit: If validation fails.
+    """
+    if not file.exists():
+        typer.echo(f"Error: File not found: {file}", err=True)
+        raise typer.Exit(1)
+
+    if not file.suffix == ".py":
+        typer.echo(f"Error: File must be a Python file: {file}", err=True)
+        raise typer.Exit(1)
+
+
+def install_requirements(file: Path) -> None:
+    """Extract and install requirements from a Python file.
+
+    This function solves the chicken-and-egg problem: we need to install packages
+    before importing the file, but the requirements are specified inside the file.
+    Solution: use AST parsing to extract requirements without executing the code.
+
+    Args:
+        file: Python file to extract requirements from.
+
+    Raises:
+        typer.Exit: If extraction or installation fails.
+    """
+    # Extract requirements via AST (parse without executing)
+    # This reads @jlserve.app(requirements=[...]) without importing
+    try:
+        requirements = extract_requirements_from_file(str(file))
+    except SyntaxError as e:
+        typer.echo(f"Error: Invalid Python syntax in {file}: {e}", err=True)
+        raise typer.Exit(1)
+    except Exception as e:
+        typer.echo(f"Error: Failed to extract requirements from {file}: {e}", err=True)
+        raise typer.Exit(1)
+
+    # Install requirements using uv (fast, skips if already installed)
+    if requirements:
+        typer.echo(f"Installing requirements: {', '.join(requirements)}")
+        try:
+            subprocess.run(
+                ["uv", "pip", "install", *requirements],
+                check=True,
+            )
+        except subprocess.CalledProcessError as e:
+            typer.echo(f"Error: Failed to install requirements: {e}", err=True)
+            raise typer.Exit(1)
+        except FileNotFoundError:
+            typer.echo(
+                "Error: 'uv' command not found. Please install uv: https://github.com/astral-sh/uv",
+                err=True,
+            )
+            raise typer.Exit(1)
+
+
+def load_app_class(file: Path) -> Type:
+    """Load a Python file and return the registered app class.
+
+    Uses dynamic import to load the user's Python file and retrieve the
+    @jlserve.app() decorated class from the global registry.
+
+    Args:
+        file: Python file containing a @jlserve.app() class.
+
+    Returns:
+        The registered app class.
+
+    Raises:
+        typer.Exit: If loading fails or no app is found.
+    """
+    # Clear any previously registered app from the global registry
+    # This ensures we only get the app from the current file
+    _reset_registry()
+
+    # Dynamically import the user's Python file
+    spec = importlib.util.spec_from_file_location("user_module", file)
+    if spec is None or spec.loader is None:
+        typer.echo(f"Error: Could not load file: {file}", err=True)
+        raise typer.Exit(1)
+
+    # Create module and register in sys.modules
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["user_module"] = module
+
+    # Execute the module (this triggers @jlserve.app() decorator registration)
+    try:
+        spec.loader.exec_module(module)
+    except Exception as e:
+        # Check if it's a MultipleAppsError (only one @jlserve.app() allowed)
+        if "MultipleAppsError" in type(e).__name__ or "multiple" in str(e).lower():
+            typer.echo(f"Error: {e}", err=True)
+            raise typer.Exit(1)
+        # Re-raise other exceptions (import errors, syntax errors, etc.)
+        raise
+
+    # Retrieve the app class from the global registry
+    app_cls = get_registered_app()
+    if app_cls is None:
+        typer.echo(
+            "Error: No app found. Did you decorate a class with @jlserve.app()?",
+            err=True,
+        )
+        raise typer.Exit(1)
+
+    return app_cls

--- a/jlserve/config.py
+++ b/jlserve/config.py
@@ -1,0 +1,38 @@
+"""Configuration and environment management for JLServe."""
+
+import os
+from pathlib import Path
+
+from jlserve.exceptions import CacheConfigError
+
+
+def get_jlserve_cache_dir() -> Path:
+    """Get and validate JLSERVE_CACHE_DIR from environment.
+
+    Returns:
+        Path to cache directory.
+
+    Raises:
+        CacheConfigError: If env var not set or directory doesn't exist.
+    """
+    cache_dir_str = os.getenv("JLSERVE_CACHE_DIR")
+
+    if not cache_dir_str:
+        raise CacheConfigError(
+            "JLSERVE_CACHE_DIR environment variable must be set. "
+            "Set it to a shared directory for caching model weights."
+        )
+
+    cache_dir = Path(cache_dir_str)
+
+    if not cache_dir.exists():
+        raise CacheConfigError(
+            f"JLSERVE_CACHE_DIR directory does not exist: {cache_dir}"
+        )
+
+    if not cache_dir.is_dir():
+        raise CacheConfigError(
+            f"JLSERVE_CACHE_DIR is not a directory: {cache_dir}"
+        )
+
+    return cache_dir

--- a/jlserve/config_test.py
+++ b/jlserve/config_test.py
@@ -1,0 +1,56 @@
+"""Tests for configuration and environment management."""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from jlserve.config import get_jlserve_cache_dir
+from jlserve.exceptions import CacheConfigError
+
+
+def test_cache_dir_not_set(monkeypatch):
+    """Test that error is raised when JLSERVE_CACHE_DIR is not set."""
+    monkeypatch.delenv("JLSERVE_CACHE_DIR", raising=False)
+
+    with pytest.raises(CacheConfigError) as exc_info:
+        get_jlserve_cache_dir()
+
+    assert "JLSERVE_CACHE_DIR environment variable must be set" in str(exc_info.value)
+
+
+def test_cache_dir_does_not_exist(monkeypatch, tmp_path):
+    """Test that error is raised when cache directory doesn't exist."""
+    non_existent_dir = tmp_path / "does_not_exist"
+    monkeypatch.setenv("JLSERVE_CACHE_DIR", str(non_existent_dir))
+
+    with pytest.raises(CacheConfigError) as exc_info:
+        get_jlserve_cache_dir()
+
+    assert "directory does not exist" in str(exc_info.value)
+    assert str(non_existent_dir) in str(exc_info.value)
+
+
+def test_cache_dir_is_file_not_directory(monkeypatch, tmp_path):
+    """Test that error is raised when JLSERVE_CACHE_DIR points to a file."""
+    cache_file = tmp_path / "cache_file.txt"
+    cache_file.write_text("not a directory")
+    monkeypatch.setenv("JLSERVE_CACHE_DIR", str(cache_file))
+
+    with pytest.raises(CacheConfigError) as exc_info:
+        get_jlserve_cache_dir()
+
+    assert "is not a directory" in str(exc_info.value)
+    assert str(cache_file) in str(exc_info.value)
+
+
+def test_cache_dir_valid(monkeypatch, tmp_path):
+    """Test that valid cache directory is returned successfully."""
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    monkeypatch.setenv("JLSERVE_CACHE_DIR", str(cache_dir))
+
+    result = get_jlserve_cache_dir()
+
+    assert result == cache_dir
+    assert isinstance(result, Path)

--- a/jlserve/exceptions.py
+++ b/jlserve/exceptions.py
@@ -23,3 +23,9 @@ class MultipleAppsError(JLServeError):
     """Raised when multiple @jlserve.app() classes are defined in a module."""
 
     pass
+
+
+class CacheConfigError(JLServeError):
+    """Raised when cache directory configuration is invalid."""
+
+    pass

--- a/jlserve/integration_test.py
+++ b/jlserve/integration_test.py
@@ -24,6 +24,12 @@ class TestCalculatorApp:
 
         @jlserve.app()
         class Calculator:
+            def setup(self) -> None:
+                pass
+
+            def download_weights(self) -> None:
+                pass
+
             def setup(self):
                 self.operation_count = 0
 
@@ -78,6 +84,12 @@ class TestMLApp:
 
         @jlserve.app()
         class TextAnalyzer:
+            def setup(self) -> None:
+                pass
+
+            def download_weights(self) -> None:
+                pass
+
             def setup(self):
                 # Mock ML model loading
                 self.sentiment_model = lambda text: ("POSITIVE", 0.95)
@@ -134,6 +146,12 @@ class TestSharedStateIntegration:
 
         @jlserve.app()
         class MLService:
+            def setup(self) -> None:
+                pass
+
+            def download_weights(self) -> None:
+                pass
+
             def setup(self):
                 # Simulate loading a heavy ML model
                 self.model_name = "linear_model_v1"
@@ -184,6 +202,12 @@ class TestCustomPaths:
 
         @jlserve.app()
         class MathOperations:
+            def setup(self) -> None:
+                pass
+
+            def download_weights(self) -> None:
+                pass
+
             @jlserve.endpoint(path="/v1/double")
             def double(self, input: NumberInput) -> NumberOutput:
                 return NumberOutput(result=input.n * 2)
@@ -219,6 +243,12 @@ class TestMinimalApp:
 
         @jlserve.app()
         class Math:
+            def setup(self) -> None:
+                pass
+
+            def download_weights(self) -> None:
+                pass
+
             @jlserve.endpoint()
             def double(self, i: In) -> Out:
                 return Out(y=i.x * 2)

--- a/jlserve/server_test.py
+++ b/jlserve/server_test.py
@@ -35,6 +35,12 @@ class TestCreateApp:
 
         @jlserve.app()
         class MyApp:
+            def setup(self) -> None:
+                pass
+
+            def download_weights(self) -> None:
+                pass
+
             @jlserve.endpoint()
             def process(self, input: Input) -> Output:
                 return Output(result=input.value * 2)
@@ -47,6 +53,12 @@ class TestCreateApp:
 
         @jlserve.app(name="Calculator")
         class MyApp:
+            def setup(self) -> None:
+                pass
+
+            def download_weights(self) -> None:
+                pass
+
             @jlserve.endpoint()
             def add(self, input: TwoNumbers) -> Result:
                 return Result(result=input.a + input.b)
@@ -59,6 +71,12 @@ class TestCreateApp:
 
         @jlserve.app()
         class MyCalculator:
+            def setup(self) -> None:
+                pass
+
+            def download_weights(self) -> None:
+                pass
+
             @jlserve.endpoint()
             def add(self, input: TwoNumbers) -> Result:
                 return Result(result=input.a + input.b)
@@ -82,6 +100,12 @@ class TestMultiRouteRegistration:
 
         @jlserve.app()
         class Calculator:
+            def setup(self) -> None:
+                pass
+
+            def download_weights(self) -> None:
+                pass
+
             @jlserve.endpoint()
             def add(self, input: TwoNumbers) -> Result:
                 return Result(result=input.a + input.b)
@@ -102,6 +126,12 @@ class TestMultiRouteRegistration:
 
         @jlserve.app()
         class Calculator:
+            def setup(self) -> None:
+                pass
+
+            def download_weights(self) -> None:
+                pass
+
             @jlserve.endpoint(path="/plus")
             def add(self, input: TwoNumbers) -> Result:
                 return Result(result=input.a + input.b)
@@ -127,6 +157,12 @@ class TestEndpointRoutes:
 
         @jlserve.app()
         class Calculator:
+            def setup(self) -> None:
+                pass
+
+            def download_weights(self) -> None:
+                pass
+
             @jlserve.endpoint()
             def add(self, input: TwoNumbers) -> Result:
                 return Result(result=input.a + input.b)
@@ -142,6 +178,12 @@ class TestEndpointRoutes:
 
         @jlserve.app()
         class Calculator:
+            def setup(self) -> None:
+                pass
+
+            def download_weights(self) -> None:
+                pass
+
             @jlserve.endpoint()
             def subtract(self, input: TwoNumbers) -> Result:
                 return Result(result=input.a - input.b)
@@ -157,6 +199,12 @@ class TestEndpointRoutes:
 
         @jlserve.app()
         class Calculator:
+            def setup(self) -> None:
+                pass
+
+            def download_weights(self) -> None:
+                pass
+
             @jlserve.endpoint()
             def add(self, input: TwoNumbers) -> Result:
                 return Result(result=input.a + input.b)
@@ -180,6 +228,12 @@ class TestEndpointRoutes:
 
         @jlserve.app()
         class Calculator:
+            def setup(self) -> None:
+                pass
+
+            def download_weights(self) -> None:
+                pass
+
             @jlserve.endpoint()
             def add(self, input: TwoNumbers) -> Result:
                 return Result(result=input.a + input.b)
@@ -198,6 +252,12 @@ class TestSharedState:
 
         @jlserve.app()
         class Counter:
+            def setup(self) -> None:
+                pass
+
+            def download_weights(self) -> None:
+                pass
+
             def __init__(self):
                 self.count = 0
 
@@ -225,6 +285,12 @@ class TestSharedState:
 
         @jlserve.app()
         class Calculator:
+            def setup(self) -> None:
+                pass
+
+            def download_weights(self) -> None:
+                pass
+
             def setup(self):
                 self.multiplier = 10
 
@@ -246,6 +312,12 @@ class TestSetupMethod:
 
         @jlserve.app()
         class MyApp:
+            def setup(self) -> None:
+                pass
+
+            def download_weights(self) -> None:
+                pass
+
             def setup(self):
                 self.prefix = "Processed"
 
@@ -264,6 +336,12 @@ class TestSetupMethod:
 
         @jlserve.app()
         class MyApp:
+            def setup(self) -> None:
+                pass
+
+            def download_weights(self) -> None:
+                pass
+
             @jlserve.endpoint()
             def process(self, input: Input) -> Output:
                 return Output(result=input.value * 2)
@@ -279,6 +357,12 @@ class TestSetupMethod:
 
         @jlserve.app()
         class MyApp:
+            def setup(self) -> None:
+                pass
+
+            def download_weights(self) -> None:
+                pass
+
             def setup(self):
                 raise RuntimeError("Setup failed!")
 
@@ -301,6 +385,12 @@ class TestErrorHandling:
 
         @jlserve.app()
         class MyApp:
+            def setup(self) -> None:
+                pass
+
+            def download_weights(self) -> None:
+                pass
+
             @jlserve.endpoint()
             def failing(self, input: Input) -> Output:
                 raise ValueError("Something went wrong")
@@ -320,6 +410,12 @@ class TestOpenAPIDocs:
 
         @jlserve.app(name="Calculator")
         class Calculator:
+            def setup(self) -> None:
+                pass
+
+            def download_weights(self) -> None:
+                pass
+
             @jlserve.endpoint()
             def add(self, input: TwoNumbers) -> Result:
                 return Result(result=input.a + input.b)
@@ -335,6 +431,12 @@ class TestOpenAPIDocs:
 
         @jlserve.app(name="Calculator")
         class Calculator:
+            def setup(self) -> None:
+                pass
+
+            def download_weights(self) -> None:
+                pass
+
             @jlserve.endpoint()
             def add(self, input: TwoNumbers) -> Result:
                 return Result(result=input.a + input.b)

--- a/jlserve/validator.py
+++ b/jlserve/validator.py
@@ -9,11 +9,13 @@ from jlserve.decorator import get_endpoint_methods
 from jlserve.exceptions import EndpointValidationError
 
 
-def validate_app(cls: Type) -> None:
+def validate_app(cls: Type, require_download_weights: bool = False) -> None:
     """Validate that an app class meets all requirements.
 
     Args:
         cls: The app class to validate.
+        require_download_weights: If True, validates that the app has a download_weights()
+            method with the correct signature. Used by `jlserve build` command.
 
     Raises:
         EndpointValidationError: If validation fails.
@@ -22,6 +24,8 @@ def validate_app(cls: Type) -> None:
     validate_has_endpoint_methods(cls)
     validate_endpoint_methods(cls)
     validate_no_duplicate_paths(cls)
+    if require_download_weights:
+        validate_download_weights_method(cls)
 
 
 def validate_is_jlserve_app(cls: Type) -> None:

--- a/jlserve/validator.py
+++ b/jlserve/validator.py
@@ -9,13 +9,11 @@ from jlserve.decorator import get_endpoint_methods
 from jlserve.exceptions import EndpointValidationError
 
 
-def validate_app(cls: Type, require_download_weights: bool = False) -> None:
+def validate_app(cls: Type) -> None:
     """Validate that an app class meets all requirements.
 
     Args:
         cls: The app class to validate.
-        require_download_weights: If True, validates that the app has a download_weights()
-            method with the correct signature. Used by `jlserve build` command.
 
     Raises:
         EndpointValidationError: If validation fails.
@@ -24,8 +22,8 @@ def validate_app(cls: Type, require_download_weights: bool = False) -> None:
     validate_has_endpoint_methods(cls)
     validate_endpoint_methods(cls)
     validate_no_duplicate_paths(cls)
-    if require_download_weights:
-        validate_download_weights_method(cls)
+    validate_setup_method(cls)
+    validate_download_weights_method(cls)
 
 
 def validate_is_jlserve_app(cls: Type) -> None:
@@ -181,3 +179,59 @@ def get_method_output_type(method: Callable) -> Type[BaseModel]:
     """
     hints = get_type_hints(method)
     return hints["return"]
+
+
+def _validate_lifecycle_method(cls: Type, method_name: str) -> None:
+    """Validate that a lifecycle method exists and has correct signature.
+
+    Args:
+        cls: The app class to validate.
+        method_name: Name of the lifecycle method (e.g., 'setup', 'download_weights').
+
+    Raises:
+        EndpointValidationError: If method is missing or has wrong signature.
+    """
+    if not hasattr(cls, method_name):
+        raise EndpointValidationError(
+            f"App {cls.__name__} must define a {method_name}() method"
+        )
+
+    method = getattr(cls, method_name)
+
+    if not callable(method):
+        raise EndpointValidationError(
+            f"{method_name} must be a method in {cls.__name__}, got {type(method).__name__}"
+        )
+
+    sig = inspect.signature(method)
+    params = list(sig.parameters.keys())
+
+    if params != ["self"]:
+        raise EndpointValidationError(
+            f"{method_name}() in {cls.__name__} must only accept 'self', got parameters: {params}"
+        )
+
+    hints = get_type_hints(method)
+    return_type = hints.get("return")
+    if return_type is not None and return_type is not type(None):
+        raise EndpointValidationError(
+            f"{method_name}() in {cls.__name__} must return None, got {return_type}"
+        )
+
+
+def validate_setup_method(cls: Type) -> None:
+    """Validate that the app has a setup() method with correct signature.
+
+    Raises:
+        EndpointValidationError: If method is missing or has wrong signature.
+    """
+    _validate_lifecycle_method(cls, "setup")
+
+
+def validate_download_weights_method(cls: Type) -> None:
+    """Validate that the app has a download_weights() method with correct signature.
+
+    Raises:
+        EndpointValidationError: If method is missing or has wrong signature.
+    """
+    _validate_lifecycle_method(cls, "download_weights")

--- a/tmp/issue-15-task-list.md
+++ b/tmp/issue-15-task-list.md
@@ -1,0 +1,100 @@
+# Issue #15: Add `jlserve build` Command for Containerized Deployments
+
+We are working on this issue. https://github.com/svishnu88/jlserve/issues/15
+
+## High-Level Task List
+
+### Phase 1: Environment Variable Support ✅
+- [x] Add environment variable validation utilities
+  - [x] `JLSERVE_CACHE_DIR` validator (required for both build and dev)
+  - [x] `UV_CACHE_DIR` - decided not needed (UV handles internally)
+- [x] Create configuration module for cache directory management
+- [x] Add tests for environment variable validation
+
+**Implementation:**
+- Created `jlserve/config.py` with `get_jlserve_cache_dir()` function
+- Added `CacheConfigError` exception to `jlserve/exceptions.py`
+- Created comprehensive tests in `jlserve/config_test.py`
+- All tests passing (4/4 config tests, 105/105 total tests)
+
+### Phase 2: Download Weights Lifecycle Method ✅
+- [x] Update decorator/validator to recognize `download_weights()` method
+  - [x] Add validation that method exists on app class
+  - [x] Add validation that method has correct signature (no params, no return)
+  - [x] Make it required for all apps (not just build)
+- [x] Document `download_weights()` pattern in docstrings
+- [x] Add tests for method presence/signature validation
+
+**Implementation:**
+- Created shared `_validate_lifecycle_method()` helper in `jlserve/validator.py`
+- Added `validate_setup_method()` and `validate_download_weights_method()` validators
+- Both methods now required for all apps (enforced by `validate_app()`)
+- Added 24 comprehensive tests covering all validation scenarios
+- Updated all existing test apps (38 apps) to include both lifecycle methods
+- Validators ensure: method exists, is callable, only accepts 'self', returns None
+- All tests passing (129/129 total tests)
+
+### Phase 3: Build Command Implementation
+- [ ] Create `jlserve build` CLI command in cli.py
+  - [ ] Add Typer command definition
+  - [ ] Accept file path argument
+  - [ ] Validate JLSERVE_CACHE_DIR environment variable
+- [ ] Implement build workflow:
+  - [ ] Extract requirements from Python file (scan imports/app)
+  - [ ] Install dependencies using `uv pip install`
+  - [ ] Load app class and call `download_weights()`
+  - [ ] Optionally validate by calling `setup()`
+- [ ] Add proper error handling and user feedback
+- [ ] Add tests for build command
+
+### Phase 4: Requirement Extraction
+- [ ] Create utility to extract Python dependencies from app file
+  - [ ] Option 1: Parse imports using AST
+  - [ ] Option 2: Use existing requirements.txt if present
+  - [ ] Option 3: Infer from pyproject.toml dependencies
+- [ ] Handle edge cases (missing dependencies, version conflicts)
+- [ ] Add tests for requirement extraction
+
+### Phase 5: Update Dev Command
+- [ ] Modify `jlserve dev` to check JLSERVE_CACHE_DIR
+  - [ ] Log warning if not set (weights may be re-downloaded)
+  - [ ] Skip calling `download_weights()` - rely on cache
+- [ ] Update lifespan handler to work with cached weights
+- [ ] Add tests for dev command with/without cache
+
+### Phase 6: Integration & Testing
+- [ ] End-to-end test: build → dev workflow
+- [ ] Test with actual model weights (mock HuggingFace download)
+- [ ] Test cache reuse across multiple builds
+- [ ] Test error cases (missing cache dir, failed downloads)
+- [ ] Add example app demonstrating the pattern
+
+### Phase 7: Documentation
+- [ ] Update README with `jlserve build` usage
+- [ ] Document environment variables (JLSERVE_CACHE_DIR, UV_CACHE_DIR)
+- [ ] Add example showing download_weights() implementation
+- [ ] Add Dockerfile example for containerized deployment
+- [ ] Update CLAUDE.md with new commands and patterns
+
+## Key Design Decisions to Validate
+
+1. **Should `download_weights()` be required for all apps or only when using `build`?**
+   - Proposal: Optional in general, but required validation when `jlserve build` is used
+
+2. **How to handle requirements extraction?**
+   - Need to decide between AST parsing vs. requirements.txt vs. pyproject.toml
+
+3. **Should `setup()` validation be mandatory or optional in build?**
+   - Proposal: Optional with --validate flag
+
+4. **Error handling for missing cache directory** ✅ DECIDED
+   - Both Build and Dev: Hard error (required)
+   - Rationale: Simpler, more predictable behavior. Cache dir should always be set.
+
+## Success Criteria
+
+- [ ] `jlserve build app.py` successfully downloads dependencies and weights to cache
+- [ ] `jlserve dev app.py` reuses cached weights without re-downloading
+- [ ] Validation catches missing `download_weights()` method when using build
+- [ ] Documentation clearly explains the containerized deployment pattern
+- [ ] All tests pass including integration tests

--- a/tmp/issue-15-task-list.md
+++ b/tmp/issue-15-task-list.md
@@ -34,60 +34,93 @@ We are working on this issue. https://github.com/svishnu88/jlserve/issues/15
 - Validators ensure: method exists, is callable, only accepts 'self', returns None
 - All tests passing (129/129 total tests)
 
-### Phase 3: Build Command Implementation
-- [ ] Create `jlserve build` CLI command in cli.py
-  - [ ] Add Typer command definition
-  - [ ] Accept file path argument
-  - [ ] Validate JLSERVE_CACHE_DIR environment variable
-- [ ] Implement build workflow:
-  - [ ] Extract requirements from Python file (scan imports/app)
-  - [ ] Install dependencies using `uv pip install`
-  - [ ] Load app class and call `download_weights()`
-  - [ ] Optionally validate by calling `setup()`
-- [ ] Add proper error handling and user feedback
-- [ ] Add tests for build command
+### Phase 3: Build Command Implementation ✅
+- [x] Create `jlserve build` CLI command in cli.py
+  - [x] Add Typer command definition
+  - [x] Accept file path argument
+  - [x] Validate JLSERVE_CACHE_DIR environment variable
+- [x] Implement build workflow:
+  - [x] Extract requirements from Python file (scan imports/app)
+  - [x] Install dependencies using `uv pip install`
+  - [x] Load app class and call `download_weights()`
+  - [x] ~~Optionally validate by calling `setup()`~~ (deferred - not needed for Phase 3)
+- [x] Add proper error handling and user feedback
+- [x] Add tests for build command
 
-### Phase 4: Requirement Extraction
-- [ ] Create utility to extract Python dependencies from app file
-  - [ ] Option 1: Parse imports using AST
-  - [ ] Option 2: Use existing requirements.txt if present
-  - [ ] Option 3: Infer from pyproject.toml dependencies
-- [ ] Handle edge cases (missing dependencies, version conflicts)
-- [ ] Add tests for requirement extraction
+**Implementation:**
+- Created `jlserve/cli_utils.py` with extracted helper functions:
+  - `validate_python_file()` - File validation
+  - `install_requirements()` - Dependency installation
+  - `load_app_class()` - App loading and registration
+- Refactored `dev` command to use shared utilities
+- Implemented `build` command with:
+  - Cache directory validation via `get_jlserve_cache_dir()`
+  - Requirements installation (reuses existing logic)
+  - App validation via `validate_app()`
+  - App instantiation and `download_weights()` call
+  - Clear user feedback with ✓ checkmarks
+- Added 7 comprehensive tests in `TestBuildCommand` class:
+  - test_build_success - Happy path
+  - test_build_file_not_found - File validation
+  - test_build_file_must_be_python - File type validation
+  - test_build_cache_dir_not_set - Cache directory requirement
+  - test_build_download_weights_fails - Error handling
+  - test_build_installs_requirements - Requirements installation
+  - test_build_validates_app_structure - App validation
+- All tests passing (124/124 total tests)
 
-### Phase 5: Update Dev Command
-- [ ] Modify `jlserve dev` to check JLSERVE_CACHE_DIR
-  - [ ] Log warning if not set (weights may be re-downloaded)
-  - [ ] Skip calling `download_weights()` - rely on cache
-- [ ] Update lifespan handler to work with cached weights
-- [ ] Add tests for dev command with/without cache
+### Phase 4: Update Dev Command ✅
+- [x] Modify `jlserve dev` to check JLSERVE_CACHE_DIR and marker file
+  - [x] Check JLSERVE_CACHE_DIR is set (hard error if missing)
+  - [x] Check for `.jlserve-build-complete` marker file (hard error if missing)
+  - [x] Provide clear error messages guiding user to run `jlserve build` first
+- [x] Update `jlserve build` to create marker file after successful build
+  - [x] Create `.jlserve-build-complete` marker in cache directory
+  - [x] Only create marker after `download_weights()` succeeds
+- [x] Add tests for marker file validation
+  - [x] test_dev_fails_when_cache_dir_not_set
+  - [x] test_dev_fails_when_marker_file_missing
+  - [x] test_dev_succeeds_when_marker_file_exists
+  - [x] test_build_creates_marker_file
+- [x] Fix existing tests to work with marker file requirement
+  - [x] Updated all dev command tests to set up cache with marker
+  - [x] Updated all build command tests to use real temp directories
 
-### Phase 6: Integration & Testing
-- [ ] End-to-end test: build → dev workflow
-- [ ] Test with actual model weights (mock HuggingFace download)
-- [ ] Test cache reuse across multiple builds
-- [ ] Test error cases (missing cache dir, failed downloads)
-- [ ] Add example app demonstrating the pattern
+**Implementation:**
+- Modified `jlserve/cli.py` dev command (lines 37-64):
+  - Added cache directory validation with helpful error messages
+  - Added marker file check with guidance to run `jlserve build`
+  - Exits with code 1 if either check fails
+- Modified `jlserve/cli.py` build command (lines 148-151):
+  - Creates `.jlserve-build-complete` marker after successful `download_weights()`
+  - Marker indicates build completed successfully
+- Added comprehensive tests in `jlserve/cli_test.py`:
+  - New test class `TestDevCommandMarkerValidation` with 3 marker validation tests
+  - New test `test_build_creates_marker_file` in `TestBuildCommand`
+  - Fixed 10 existing tests to set up cache with marker file
+- All tests passing (128/128 total tests)
 
-### Phase 7: Documentation
+**Design Decision: Marker File Approach** ✅ DECIDED
+- Uses `.jlserve-build-complete` marker file in cache directory
+- Performance impact: ~1 microsecond (negligible)
+- Clear separation: build creates marker, dev checks marker
+- Simple and reliable validation mechanism
+
+### Phase 5: Documentation
 - [ ] Update README with `jlserve build` usage
-- [ ] Document environment variables (JLSERVE_CACHE_DIR, UV_CACHE_DIR)
-- [ ] Add example showing download_weights() implementation
-- [ ] Add Dockerfile example for containerized deployment
-- [ ] Update CLAUDE.md with new commands and patterns
+- [ ] Document environment variables (JLSERVE_CACHE_DIR)
+
 
 ## Key Design Decisions to Validate
 
-1. **Should `download_weights()` be required for all apps or only when using `build`?**
-   - Proposal: Optional in general, but required validation when `jlserve build` is used
+1. **Should `download_weights()` be required for all apps or only when using `build`?** ✅ DECIDED
+   - Decision: Required for all apps (enforced by validator)
+   - Rationale: Simplifies the pattern and makes it consistent
 
-2. **How to handle requirements extraction?**
-   - Need to decide between AST parsing vs. requirements.txt vs. pyproject.toml
-
-3. **Should `setup()` validation be mandatory or optional in build?**
+2. **Should `setup()` validation be mandatory or optional in build?**
    - Proposal: Optional with --validate flag
 
-4. **Error handling for missing cache directory** ✅ DECIDED
+3. **Error handling for missing cache directory** ✅ DECIDED
    - Both Build and Dev: Hard error (required)
    - Rationale: Simpler, more predictable behavior. Cache dir should always be set.
 


### PR DESCRIPTION
## Summary

Simplified the cache configuration by using a single environment variable (`JLSERVE_CACHE_DIR`) for both model weights and Python packages. This makes JLServe easier to use in containerized environments like JarvisLabs.

## Changes

### Code Changes
- ✅ Removed `UV_CACHE_DIR` validation from `cli.py` (dev and build commands)
- ✅ Removed `get_uv_cache_dir()` from `config.py`  
- ✅ Updated `install_requirements()` to automatically set `UV_CACHE_DIR` from `JLSERVE_CACHE_DIR`
- ✅ Removed UV_CACHE_DIR tests from `config_test.py` and `cli_test.py`

### Documentation Updates
- ✅ Documented `jlserve build` command in README
- ✅ Added Environment Variables section
- ✅ Added "Weight Caching for Fast Startup" section explaining the build/dev workflow
- ✅ Updated lifecycle methods table (both `download_weights()` and `setup()` now required)
- ✅ Updated Quick Start and ML Inference examples to show complete workflow

## Before vs After

**Before:**
```bash
export JLSERVE_CACHE_DIR=/path/to/cache
export UV_CACHE_DIR=/path/to/uv_cache
jlserve build app.py
jlserve dev app.py
```

**After:**
```bash
export JLSERVE_CACHE_DIR=/path/to/cache
jlserve build app.py
jlserve dev app.py
```

## Testing

All 128 tests passing ✅

## Related Issue

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)